### PR TITLE
MTL-1800 disable services

### DIFF
--- a/roles/ncn-common-install/defaults/main.yml
+++ b/roles/ncn-common-install/defaults/main.yml
@@ -1,0 +1,90 @@
+---
+services_common:
+  - name: ca-certificates.service
+    enabled: yes
+    state: stopped
+  - name: chronyd.service
+    enabled: yes
+    state: stopped
+  - name: getty@tty1.service
+    enabled: yes
+    state: stopped
+  - name: goss-servers
+    enabled: yes
+    state: started
+  - name: issue-generator.service
+    enabled: yes
+    state: stopped
+  - name: kdump-early.service
+    enabled: yes
+    state: stopped
+  - name: kdump.service
+    enabled: yes
+    state: stopped
+  - name: lldpad.service
+    enabled: yes
+    state: started
+  - name: multi-user.target
+    enabled: yes
+    state: started
+  - name: postfix.service
+    enabled: no
+    state: stopped
+  - name: purge-kernels.service
+    enabled: yes
+    state: stopped
+  - name: rasdaemon.service
+    enabled: yes
+    state: stopped
+  - name: rc-local.service
+    enabled: yes
+    state: stopped
+  - name: rollback.service
+    enabled: yes
+    state: stopped
+  - name: serial-getty@ttyS0.service
+    enabled: yes
+    state: stopped
+  - name: spire-agent.service
+    enabled: yes
+    state: stopped
+  - name: sshd.service
+    enabled: yes
+    state: stopped
+  - name: wicked.service
+    enabled: yes
+    state: stopped
+  - name: wickedd-auto4.service
+    enabled: yes
+    state: stopped
+  - name: wickedd-dhcp4.service
+    enabled: yes
+    state: stopped
+  - name: wickedd-dhcp6.service
+    enabled: yes
+    state: stopped
+  - name: wickedd-nanny.service
+    enabled: yes
+    state: stopped
+services_metal:
+  - name: ahslog
+    enabled: no
+    state: stopped
+  - name: amsd
+    enabled: no
+    state: stopped
+  - name: cpqFca
+    enabled: no
+    state: stopped
+  - name: cpqIde
+    enabled: no
+    state: stopped
+  - name: cpqScsi
+    enabled: no
+    state: stopped
+  - name: smad
+    enabled: no
+    state: stopped
+  - name: sysstat.service
+    enabled: yes
+    state: started

--- a/roles/ncn-common-install/tasks/common.yml
+++ b/roles/ncn-common-install/tasks/common.yml
@@ -1,24 +1,24 @@
 ---
 
-- name: symlink python3
+- name: Symlink python3 to python
   file:
     src: /usr/bin/python3
     dest: /usr/bin/python
     state: link
 
-- name: ensure /srv/cray/utilities locations are available for use system-wide
+- name: Ensure /srv/cray/utilities locations are available for use system-wide
   file:
     src: /srv/cray/utilities/common/craysys/craysys
     dest: /bin/craysys
     state: link
 
-- name: ensure craysys is executable
+- name: Ensure craysys is executable
   file:
     path: /srv/cray/utilities/common/craysys/craysys
     state: file
     mode: a+x
 
-- name: create cray.sh profile
+- name: Create cray.sh profile
   file:
     path: /etc/profile.d/cray.sh
     state: touch
@@ -26,13 +26,13 @@
     owner: root
     group: root
 
-- name: export cray path
+- name: Export cray path
   lineinfile:
     path: /etc/profile.d/cray.sh
     regexp: '^export PYTHONPATH='
     line: 'export PYTHONPATH="/srv/cray/utilities/common"'
 
-- name: create /etc/containers
+- name: Create /etc/containers
   file:
     path: /etc/containers
     state: directory
@@ -40,7 +40,7 @@
     owner: root
     group: root
 
-- name: create storage.conf
+- name: Create storage.conf
   file:
     path: /etc/containers/storage.conf
     state: touch
@@ -48,67 +48,25 @@
     owner: root
     group: root
 
-- name: configure podman so it will run with fuse-overlayfs
+- name: Configure podman so it will run with fuse-overlayfs
   lineinfile:
     path: /etc/containers/storage.conf
     regexp: '^#?mount_program ='
     line: 'mount_program = "/usr/bin/fuse-overlayfs"'
 
-- name: enable multi-user target
-  systemd:
-    name: multi-user.target
-    enabled: yes
-    masked: no
-
-- name: get current systemd default
+- name: Get current systemd default
   command: "systemctl get-default"
   changed_when: false
   register: systemdefault
 
-- name: set default to multi-user target
+- name: Set default to multi-user target
   command: "systemctl set-default multi-user.target"
   when: "'multi-user' not in systemdefault.stdout"
 
-- name: enable services
+- name: Setup Daemons
   systemd:
-    name: "{{ item }}"
-    enabled: yes
-    masked: no
-  with_items:
-    - ca-certificates.service
-    - chronyd.service
-    - getty@tty1.service
-    - goss-servers
-    - issue-generator.service
-    - kdump-early.service
-    - kdump.service
-    - lldpad.service
-    - purge-kernels.service
-    - rasdaemon.service
-    - rc-local.service
-    - rollback.service
-    - serial-getty@ttyS0.service
-    - spire-agent.service
-    - sshd.service
-    - wicked.service
-    - wickedd-auto4.service
-    - wickedd-dhcp4.service
-    - wickedd-dhcp6.service
-    - wickedd-nanny.service
-
-# goss tests must be updated every time this list is altered
-- name: start services
-  systemd:
-    name: "{{ item }}"
-    state: started
-  with_items:
-    - goss-servers
-    - lldpad.service
-
-- name: disable postfix service
-  systemd:
-    name: "{{ item }}"
-    enabled: no
-    state: stopped
-  with_items:
-    - postfix.service
+    enabled: "{{ item.enabled }}"
+    name: "{{ item.name }}"
+    masked: "{{ item.masked | default(no) }}"
+    started: "{{ item.started }}
+  with_items: "{{ services_common }}""

--- a/roles/ncn-common-install/tasks/metal.yml
+++ b/roles/ncn-common-install/tasks/metal.yml
@@ -17,7 +17,7 @@
     enabled: yes
     masked: no
   with_items:
-    - sysstat.service
+    - 
 
 - name: copy mdadm.conf into place
   copy:
@@ -25,20 +25,14 @@
     src: /srv/cray/resources/metal/mdadm.conf
     dest: /etc/mdadm.conf
 
-# Agentless Management Service only works on servers with iLO4/5.
-# Disable by default, enable during runtime.
-- name: disable Agentless Management Daemon
+- name: Daemons
   systemd:
-    name: "{{ item }}"
-    enabled: no
-    state: stopped
-  with_items:
-    - ahslog
-    - amsd
-    - cpqFca
-    - cpqIde
-    - cpqScsi
-    - smad
+    name: "{{ item.name }}"
+    enabled: "{{ item.enabled }}"
+    masked: "{{ item.masked | default(no) }}"
+    state: "{{ item.state }}"
+  with_items: "{{ services_metal }}"
+
 
 - name: configure dhcp settings
   lineinfile:


### PR DESCRIPTION
#### Summary and Scope
<!--- Pick one below and delete the rest -->

- Fixes MTL-1800

##### Issue Type
<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->

Fixes the broken disable systemd task, and merges the enabled/disabled tasks together. Now services are listed by dictionaries in `defaults`.

#### Prerequisites

- [x] I have included documentation in my PR (or it is not required)
- [x] I tested this on internal system (x) (if yes, please include results or a description of the test)
 
#### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
#### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
