### PR TITLE
MTL-1800 Fix ncn-setup role and ensure metal-iptables is disabled

### DIFF
--- a/roles/ncn-common-setup/defaults/main.yml
+++ b/roles/ncn-common-setup/defaults/main.yml
@@ -1,0 +1,31 @@
+---
+services_google:
+  - name: google-guest-agent.service
+    enabled: yes
+    state: started
+  - name: google-osconfig-agent.service
+    enabled: yes
+    state: started
+  - name: google-oslogin-cache.service
+    enabled: yes
+    state: started
+  - name: google-oslogin-cache.timer
+    enabled: yes
+    state: started
+  - name: google-shutdown-scripts.service
+    enabled: yes
+    state: started
+  - name: google-startup-scripts.service
+    enabled: yes
+    state: started
+services_metal:
+  - name: cloud-init-oneshot
+    enabled: yes
+    state: stopped
+  - name: kdump-cray
+    enabled: yes
+    state: stopped 
+  - name: metal-iptables
+    enabled: no
+    state: stopped
+    

--- a/roles/ncn-common-setup/tasks/gcp.yml
+++ b/roles/ncn-common-setup/tasks/gcp.yml
@@ -19,18 +19,12 @@
     - google-guest-oslogin
     - google-osconfig-agent
 
-- name: enable google services and ensure they are not masked
+- name: Setup Daemons
   systemd:
-    name: "{{ item }}"
-    enabled: yes
-    masked: no
-  with_items:
-    - google-guest-agent.service
-    - google-osconfig-agent.service
-    - google-oslogin-cache.service
-    - google-oslogin-cache.timer
-    - google-shutdown-scripts.service
-    - google-startup-scripts.service
+    name: "{{ item.name }}"
+    enabled: "{{ item.enabled }}"
+    masked: "{{ item.masked | default(false) }}"
+  with_items: "{{ services_google }}"
 
 - name: stub out network interface configuration files
   copy:

--- a/roles/ncn-common-setup/tasks/metal.yml
+++ b/roles/ncn-common-setup/tasks/metal.yml
@@ -12,23 +12,6 @@
     src: /srv/cray/resources/metal/systemd/
     dest: /usr/lib/systemd/system/
 
-- name: enable metal services and ensure they are not masked
-  systemd:
-    name: "{{ item }}"
-    enabled: yes
-    masked: no
-  with_items:
-    - cloud-init-oneshot
-    - kdump-cray
-
-- name: disable services
-  systemd:
-    name: "{{ item }}"
-    enabled: yes
-    masked: no
-  with_items:
-    - metal-iptables
-
 - name: add sshd_config for metal
   copy:
     remote_src: yes

--- a/roles/ncn-common-team/defaults/main.yml
+++ b/roles/ncn-common-team/defaults/main.yml
@@ -1,0 +1,11 @@
+---
+services_common:
+  - name: cfs-state-reporter.service
+    enabled: yes
+    state: started
+  - name: cray-heartbeat.service
+    enabled: yes
+    state: started
+  - name: csm-node-identity.service
+    enabled: yes
+    state: started

--- a/roles/ncn-common-team/tasks/common.yml
+++ b/roles/ncn-common-team/tasks/common.yml
@@ -1,21 +1,11 @@
 ---
 
-- name: enable HPE CSM CMS Services
+- name: Setup Daemons
   systemd:
-    name: "{{ item }}"
-    enabled: yes
-    masked: no
-  with_items:
-    - cfs-state-reporter.service
-
-- name: enable HPE Cray OS services
-  systemd:
-    name: "{{ item }}"
-    enabled: yes
-    masked: no
-  with_items:
-    - cray-heartbeat.service
-    - csm-node-identity.service
+    name: "{{ item.name }}"
+    enabled: "{{ item.enabled }}"
+    masked: "{{ item.masked | default(false) }}"
+  with_items: "{{ services_common }}"
 
 - name: rsyslog config to ensure the NCN OS logs are routed to SMF
   copy:


### PR DESCRIPTION
These tasks were reverted in my work, sloppy on my part.

This ensures the rest of the roles use a defaults file listing the daemons.

This also changes the _team_ role's tasks for setting daemons up into something more generic.