### PR TITLE
MTL-1288 Change from ignore to none

### DIFF
--- a/roles/ncn-common-setup/files/srv/cray/resources/metal/mdadm.conf
+++ b/roles/ncn-common-setup/files/srv/cray/resources/metal/mdadm.conf
@@ -1,2 +1,2 @@
-# HOMEHOST <ignore> 'do not include any hostname info in the RAID's ID, just use the FSLabel'
-HOMEHOST <ignore>
+# HOMEHOST <none> 'do not include any hostname info in the RAID's ID, just use the FSLabel'
+HOMEHOST <none>


### PR DESCRIPTION
This should never, ever acknowledge the hostname. Using 'ignore' can occasionally use the localhost hostname.

This ensures that mdadm in Linux continues to use no-hostname in it's RAID handles within `/dev/md/*`. The initrd is already taken care of from MTL-1288's PR to dracut-metal-mdsquash here: https://github.com/Cray-HPE/dracut-metal-mdsquash/blob/main/90metalmdsquash/mdadm.conf