### PR TITLE
MTL-1761 Use a library for storing dracut inputs

### DIFF
--- a/roles/ncn-common-setup/files/srv/cray/scripts/common/cleanup-kis-artifacts.sh
+++ b/roles/ncn-common-setup/files/srv/cray/scripts/common/cleanup-kis-artifacts.sh
@@ -1,7 +1,27 @@
 #!/bin/bash
-
+#
+# MIT License
+#
+# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
 set -e
 
-umount /mnt/squashfs
-rm -rf /mnt/squashfs
 rm -rf /squashfs

--- a/roles/ncn-common-setup/files/srv/cray/scripts/common/dracut-lib.sh
+++ b/roles/ncn-common-setup/files/srv/cray/scripts/common/dracut-lib.sh
@@ -23,28 +23,16 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 
-# This script does not use bind mounts and thus executes correctly in a container.
-set -e
-set -x
+# Dracut Arguments
+export OMIT=( "btrfs" "cifs" "dmraid" "dmsquash-live-ntfs" "fcoe" "fcoe-uefi" "iscsi" "modsign" "multipath" "nbd" "nfs" "ntfs-3g" )
+export OMIT_DRIVERS=( "ecb" "hmac" "md5" )
+export ADD=( "mdraid" )
+export FORCE_ADD=( "dmsquash-live" "livenet" "mdraid" )
+export INSTALL=( "less" "rmdir" "sgdisk" "vgremove" "wipefs" )
 
-
-# Source common dracut parameters.
-. "$(dirname $0)/dracut-lib.sh"
-
-echo "Generating initrd..."
-
-dracut \
---force \
---omit "$(printf '%s' "${OMIT[*]}")" \
---omit-drivers "$(printf '%s' "${OMIT_DRIVERS[*]}")" \
---add "$(printf '%s' "${ADD[*]}")" \
---force-add "$(printf '%s' "${FORCE_ADD[*]}")" \
---install "$(printf '%s' "${INSTALL[*]}")" \
---kver "${KVER}" \
---no-hostonly \
---no-hostonly-cmdline \
---printsize \
---xz \
-"/boot/initrd-${KVER}"
-
-exit 0
+# Kernel Version
+version_full=$(rpm -q --queryformat "%{VERSION}-%{RELEASE}.%{ARCH}\n" kernel-default)
+version_base=${version_full%%-*}
+version_suse=${version_full##*-}
+version_suse=${version_suse%.*.*}
+export KVER="${version_base}-${version_suse}-default"


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: MTL-1761

#### Issue Type

<!--- Delete un-needed bullets -->

- RFE Pull Request

<!--- words; describe what this change is and what it is for. -->
We often repeat static inputs to dracut in our scripts, this adds a library and updates the following scripts to use the library:
- `create-ims-initrd.sh`
- `create-kdump-artifacts.sh`
- `create-kexec-initrd.sh`
- `create-kis-artifacts.sh`

Each script was tested on metal to verify that the modifications worked.

Lastly this also resolves an old problem where a mount point would exist after running `create-kis-artifacts.sh`:

```bash
redbull-ncn-m001-pit: # mount | grep 'squashfs-root'
/dev/sdd4 on /var/www/ephemeral/data/k8s/0.3.12/squashfs-root/mnt/squashfs type ext4 (rw,noatime)
redbull-ncn-m001-pit: #umount /var/www/ephemeral/data/k8s/0.3.12/squashfs-root/mnt/squashfs
```
That was fixed by adding a `trap` to `create-kis-artifacts.sh` that `umounts` the `/mnt/squashfs` dir from within the chroot before exiting.

Additionally, @dmjacobsen 's recommendation to use `unshare` vs. `chroot` in `create-kis-artifacts.sh` is implemented.

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [x] I have included documentation in my PR (or it is not required)
- [x] I tested this on internal system (if yes, please include results or a description of the test)

 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
This provides less risk because maintainers can refer to lengthy dracut params via a library.