### PR TITLE
CASMTRIAGE-3591 Reduce kdump script

### DIFF
--- a/roles/ncn-common-setup/files/srv/cray/scripts/common/create-kdump-artifacts.sh
+++ b/roles/ncn-common-setup/files/srv/cray/scripts/common/create-kdump-artifacts.sh
@@ -22,213 +22,234 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-# create-kdump-artifacts.sh creates an initrd for use with kdump
-#   this specialized initrd is booted when a node crashes
-#   it is specifically designed to work with the persistent overlay and RAIDs in use in Shasta 1.4+
-set -ex
+set -euo pipefail
 
 # Source common dracut parameters.
 . "$(dirname $0)/dracut-lib.sh"
 
 # show the line that we failed and on and exit non-zero
+
 trap 'catch $? $LINENO; cleanup; exit 1' ERR
+
 # if the script is interrupted, run the cleanup function
-trap 'cleanup' INT
+trap 'cleanup' INT EXIT
 
 # catch() prints what line the script failed on, runs the cleanup function, and then exits non-zero
 catch() {
-  # Show what line the error occurred on because it can be difficult to detect in a dracut environment
-  echo "CATCH: exit code $1 occurred on line $2 in $(basename "${0}")"
-  cleanup
-  exit 1
+    # Show what line the error occurred on because it can be difficult to detect in a dracut environment
+    echo "CATCH: exit code $1 occurred on line $2 in $(basename "${0}")"
+    cleanup
+    exit 1
 }
+
 
 # cleanup() removes temporary files, puts things back where they belong, etc.
 cleanup() {
-  # Ensures things are unmounted via 'trap' even if the command fails
-  echo "CLEANUP: cleanup function running..."
-  # remove the temporary fstab file
-  if [ -f $fstab_kdump ]; then
-    rm -f $fstab_kdump
-  fi
+    echo "CLEANUP: cleanup function running ..."
 
-  # during the script this config causes complications with the dracut command
-  # so it's moved out the way; this puts it back to where it belongs
-  if [ -f /tmp/metalconf/05-metal.conf ]; then
-    mv /tmp/metalconf/05-metal.conf /etc/dracut.conf.d/
-  fi
+    # Restore the dracut config if it was removed.
+    [ ! -f /etc/dracut.conf.d/05-metal.conf ] && cp -v /run/rootfsbase/etc/dracut.conf.d/05-metal.conf /etc/dracut.conf.d/05-metal.conf
 
-  # the initrd is unpacked to modify some contents
-  # it is removed here so we can have a clean run everytime the script runs
-  if [ -d /tmp/ktmp/ ]; then
-    rm -rf /tmp/ktmp/
-  fi
-
-  systemctl disable kdump-cray
+    # Stops re-running this script on reboot
+    # TODO: This script should move to the pipeline, and the service can then be removed (MTL-1830).
+    systemctl disable kdump-cray
 }
+
 
 # check_size() offers a CAUTION message if the initrd is larger then 20MB
 # this is just a soft warning since several factors can influence running out of memory including:
 # crashkernel= parameters, drivers that are loaded, modules that are loaded, etc.
 # so it's more of a your mileage may vary message
 check_size() {
-  local initrd="$1"
-  # kdump initrds larger than 20M may run into issues with memory
-  if [[ "$(stat --format=%s $initrd)" -ge 20000000 ]]; then
-    echo "CAUTION: initrd might be too large ($(stat --format=%s $initrd)) and may OOM if used"
-  else
-    echo "initrd size is $(stat --format=%s $initrd)"
-  fi
+
+    local initrd="$1"
+    local max=20000000 # kdump initrds larger than 20M may run into issues with memory
+    
+    if [[ "$(stat --format=%s $initrd)" -ge "$max" ]]; then
+        echo >&2 "CAUTION: initrd might be too large ($(stat --format=%s $initrd)) and may OOM if used"
+    else
+        echo "initrd size is $(stat --format=%s $initrd) bytes"
+    fi
 }
 
-initrd_name="/boot/initrd-$KVER-kdump"
 
-echo "Creating initrd/kernel artifacts..."
+# FIXME: Remove this function, see notes on each block of code contained for prerequites for removal.
+function update_fstab {
 
-# kdump-specific modules to add
-kdump_add=$ADD
-kdump_add+=( 'kdump' )
+    local initrd="$1"
+    local sqfs_label="${2:-'SQFSRAID'}"
+    local live_dir="${3:-'LiveOS'}"
 
-# kdump-specific kernel parameters
-init_cmdline=$(cat /proc/cmdline)
-kdump_cmdline=()
-for cmd in $init_cmdline; do
-    # grab only the raid, live, and root directives so we can use them in kdump
-    if [[ $cmd =~ ^rd\.md.* ]] || [[ $cmd =~ ^rd\.live.* ]] || [[ $cmd =~ ^root.* ]] ; then
-      cmd=$(basename "$(echo $cmd  | awk '{print $1}')")
-      kdump_cmdline+=( "$cmd" )
-    fi
-done
-kdump_cmdline+=( "irqpoll" )
-kdump_cmdline+=( "nr_cpus=1" )
-kdump_cmdline+=( "selinux=0" )
-kdump_cmdline+=( "reset_devices" )
-kdump_cmdline+=( "cgroup_disable=memory" )
-kdump_cmdline+=( "mce=off" )
-kdump_cmdline+=( "numa=off" )
-kdump_cmdline+=( "udev.children-max=2" )
-kdump_cmdline+=( "acpi_no_memhotplug" )
-kdump_cmdline+=( "rd.neednet=0" )
-kdump_cmdline+=( "rd.shell" )
-kdump_cmdline+=( "panic=10" )
-kdump_cmdline+=( "nohpet" )
-kdump_cmdline+=( "nokaslr" )
-kdump_cmdline+=( "transparent_hugepage=never" )
-# mellanox drivers need to be blacklisted in order to prevent OOM errors
-kdump_cmdline+=( "rd.driver.blacklist=mlx5_core,mlx5_ib" )
-kdump_cmdline+=( "rd.info" )
-# adjust here if you want a break point
-#kdump_cmdline+=( "rd.break=pre-mount" )
-# uncomment to see debug info when running in the kdump initrd
-#kdump_cmdline+=( "rd.debug=1" )
+    echo "Unpacking generated initrd [$initrd] to amend fstab ..."
 
-# modules to remove
-kdump_omit=()
-kdump_omit+=( "plymouth" )
-kdump_omit+=( "resume" )
-kdump_omit+=( "usrmount" )
-kdump_omit+=( "haveged" )
-kdump_omit+=( "metaldmk8s" )
-kdump_omit+=( "metalluksetcd" )
-kdump_omit+=( "metalmdsquash" )
+    local temp=/tmp/ktmp
 
-# This will be used in fstab and translate to /var/crash on the overlay when the node comes back up.
-# This is also unique to each host and the disks it lands on
-sqfs_uuid=$(blkid -lt LABEL=SQFSRAID | tr ' ' '\n' | awk -F '"' ' /UUID/ {print $2}')
-# the above will be used in the fstab file used to facilitate mounting all the pieces we need for the overlay
-fstab_kdump=/tmp/fstab.kdump
+    [ -d $temp ] && rm -rf $temp
+    mkdir -p $temp
+    pushd $temp || exit 1
+    /usr/lib/dracut/skipcpio ${initrd} | xzcat | cpio -id
+    
+    # This hack removes the automated entry for mnt0, we have been unable to resolve where it came from.
+    # It seems to come from kdump source, likely the C code.
+    tail -n +2 etc/fstab > etc/fstab.new
+    mv etc/fstab.new etc/fstab
 
-# mount the root raid
-# mount the squashfs raid
-# mount the squash image
-# create the overlay with mount_kdump_overlay.sh
-# a fstab entry could be used here, but it ran into issues, so the pre-script just runs a 'mount' commmand instead:
-#        overlay /kdump/overlay overlay ro,relatime,lowerdir=/kdump/mnt2,upperdir=/kdump/mnt0/LiveOS/overlay-SQFSRAID-${sqfs_uuid},workdir=/kdump/mnt0/LiveOS/ovlwork 0 2
-cat << EOF > "$fstab_kdump"
-LABEL=ROOTRAID /kdump/mnt0/ xfs defaults 0 0
-LABEL=SQFSRAID /kdump/mnt1/ xfs defaults 0 0
-/kdump/mnt1/LiveOS/filesystem.squashfs /kdump/mnt2 squashfs ro,defaults 0 0
-# overlay is mounted via mount_kdump_overlay.sh
-EOF
+    # kdump/boot points to mnt0 assuming it is the `/` partition, this corrects it to point
+    # to the actual boot directory from the squash.
+    # NOTE: The boot directory won't contain the kdump initrd until we run this script in the NCN pipeline.
+    #       We assume that this directory is mounted to provide access
+    #       to the kdump initrd (not that it needs to be accessed).
+    rm -rf kdump/boot
+    ln -snf rootfsbase/boot kdump/boot
 
-# move the 05-metal.conf file out of the way while the initrd is generated
-# it causes some conflicts if it's in place when 'dracut' is called
-mkdir -p /tmp/metalconf
-mv /etc/dracut.conf.d/05-metal.conf /tmp/metalconf/
+    # /etc/sysconfig/kdump differs between the running system and in the kdump initrd.
+    # in the initrd the value is this: KDUMP_SAVEDIR="file:///mnt0/var/crash"
+    # in runtime it's KDUMP_SAVEDIR="file:////var/crash"
+    # instead of modifying KDUMP_SAVEDIR since the values don't match between each context, this symlinks
+    # where /var/crash exists in runtime to `/kdump/mnt0.
+    sqfs_uuid=$(blkid -lt LABEL=$sqfs_label | tr ' ' '\n' | awk -F '"' ' /UUID/ {print $2}')
+    rm -rf kdump/mnt0
+    ln -snf overlay/${live_dir}/overlay-$sqfs_label-$sqfs_uuid/ kdump/mnt0
 
-# generate the kdump initrd
-#   --hostonly trims down the size by keeping only what is needed for the specific host
-#   --omit omits the modules we don't want from the list crafted earlier in the script
-#   --tmpdir is needed to avoid an error where 'init is on a different filesystem' (overlay-related)
-#   --install can be used to add other binaries to the environment.  This is useful for debug, but can also be removed if the initrd needs to be smaller
-#   --force-drivers will add the driver even if --hostonly is passed, which can sometimes leave things out we actually want
-#   --filesystems are needed to support mounting the squash and using the overlay
-dracut \
-  -L 4 \
-  --force \
-  --hostonly \
-  --omit "$(printf '%s' "${kdump_omit[*]}")" \
-  --omit-drivers "$(printf '%s' "${OMIT_DRIVERS[*]}")" \
-  --add "$(printf '%s' "${kdump_add[*]}")" \
-  --install 'lsblk find df' \
-  --add-fstab ${fstab_kdump} \
-  --compress 'xz -0 --check=crc32' \
-  --kernel-cmdline "$(printf '%s' "${kdump_cmdline[*]}")" \
-  --tmpdir "/run/initramfs/overlayfs/LiveOS/overlay-SQFSRAID-${sqfs_uuid}/var/tmp" \
-  --persistent-policy by-label \
-  --force-drivers 'raid1' \
-  --filesystems 'loop overlay squashfs' \
-  ${initrd_name}
+    echo "Regenerating modified kdump initrd ..."
+    rm -f ${initrd}
+    find . | cpio -oac | xz -C crc32 -z -c > ${initrd}
+    popd
+    rm -rf $temp
+}
 
-echo "Unpacking generated initrd to modify some content..."
-mkdir -p /tmp/ktmp
 
-pushd /tmp/ktmp || exit 1
-# Unpack the existing kdump initrd
-/usr/lib/dracut/skipcpio ${initrd_name} | xzcat | cpio -id
+function build_initrd {
 
-echo "Setting ROOTDIR..."
-# The overlay will be mounted here, so create it in advance
-mkdir kdump/overlay/
+    local init_cmdline    
+    local kdump_cmdline
+    local kdump_add
+    local kdump_omit
+    local kdump_omit_drivers
 
-# The default ROOTDIR results in an OOM error, so we specifically set it to the overlay where we can write to
-# This also enables the dump files to be accessible on the next boot and live in /var/crash
-sed -i 's/^\(ROOTDIR\)=.*$/\1=\"\/kdump\/overlay\"/' lib/kdump/save_dump.sh
+    local live_dir=''
+    local live_dir_arg=''
+    local live_img=''
+    local live_img_arg=''
+    local overlay_label=''
+    local overlay_label_arg=''
+    local root=''
+    local root_arg=''
+    local sqfs_drive_url=''
+    local sqfs_label=''
+    local sqfs_label_arg=''
+    local sqfs_label_arg=''
 
-# Modify the save dir also so it saves to the correct spot
-sed -i 's/^\(KDUMP_SAVEDIR\)=.*$/\1=\"file:\/\/\/var\/crash\"/' etc/sysconfig/kdump
-# optionally, uncomment to stay in the initrd after the dump is complete
-#sed -i 's/^\(KDUMP_IMMEDIATE_REBOOT\)=.*$/\1=\"no"/' etc/sysconfig/kdump
+    # kdump-specific kernel parameters
+    init_cmdline=$(cat /proc/cmdline)
+    kdump_cmdline=()
+    for cmd in $init_cmdline; do
+        # cleans up first argument when running this script on a disk-booted system
+        if [[ $cmd =~ kernel$ ]]; then
+            cmd=$(basename "$(echo $cmd  | awk '{print $1}')")
+        fi
+        if [[ $cmd =~ ^rd\.live\.dir=.* ]]; then
+            live_dir_arg="${cmd//;/\\;}"
+        fi
+        if [[ $cmd =~ ^rd\.live\.squashimg=.* ]]; then
+            live_img_arg="${cmd//;/\\;}"
+        fi
+        if [[ $cmd =~ ^root=.* ]]; then
+            root_arg="${cmd//;/\\;}"
+            root=${root_arg#*=}
+            case "$root" in
+                live:*)
+                    sqfs_drive_url=${root#live:}
+                    sqfs_label_arg=${sqfs_drive_url#*:}
+                    ;;
+                *)
+                    echo >&2 "This kdump script does not support a root type of $root"
+                    ;;
+            esac
+        fi
+        if [[ $cmd =~ ^rd.live.overlay=.* ]]; then
+            overlay_label_arg="${cmd//;/\\;}"
+        fi
+        if [[ $cmd =~ ^rd.live.overlay.reset ]] ; then :
+        elif [[ ! $cmd =~ ^metal. ]] && [[ ! $cmd =~ ^ip=.* ]] && [[ ! $cmd =~ ^bootdev=.* ]] ; then
+            kdump_cmdline+=( "${cmd//;/\\;}" )
+        fi
+    done
+    kdump_cmdline+=( "rd.info" )
+    
+    # Resolve the filesystem and the live directory dynamically.
+    [ -n "${sqfs_label_arg:-''}" ] && sqfs_label="${sqfs_label_arg#*=}"
+    [ -z "$sqfs_label" ] && sqfs_label='SQFSRAID'
+    [ -n "${overlay_label_arg:-''}" ] && overlay_label="${overlay_label_arg##*=}"
+    [ -z "$overlay_label" ] && overlay_label='ROOTRAID'
+    [ -n "${live_dir_arg:-''}" ] && live_dir="${live_dir_arg#*=}"
+    [ -z "$live_dir" ] && live_dir='LiveOS'
+    [ -n "${live_img_arg:-''}" ] && live_img="${live_img_arg#*=}"
+    [ -z "$live_img" ] && live_img='filesystem.squashfs'
+    
+    initrd_name="/boot/initrd-${KVER}-kdump"
 
-# this is a hacky workaround to remove a rogue fstab entry in 1.2+
-# /kdump/mnt0 should be the ROOTRAID, not SQFSRAID
-# it is added by the kdump dracut module, but can be inaccurate if the root label matches the squashfs label
-# prior to this commit, earlier versions of csm will hit this issue,
-# so this can help provide backwards compatibility if kdump needs to be enabled on those environments
-sed -i '/^LABEL=SQFSRAID \/kdump\/mnt0/d' etc/fstab
+    # kdump-specific modules to add
+    kdump_add=${ADD[*]}
+    kdump_add+=( 'kdump' )
 
-# Use a here doc to create a simple pre-script that mounts the overlay
-cat << EOF > sbin/mount_kdump_overlay.sh
-mount -t overlay overlay -o rw,relatime,lowerdir=/kdump/mnt2,upperdir=/kdump/mnt0/LiveOS/overlay-SQFSRAID-${sqfs_uuid},workdir=/kdump/mnt0/LiveOS/ovlwork /kdump/overlay
-EOF
-chmod 755 sbin/mount_kdump_overlay.sh
+    # modules to remove
+    kdump_omit=${OMIT[*]}
+    kdump_omit+=( "plymouth" )
+    kdump_omit+=( "resume" )
+    kdump_omit+=( "usrmount" )
 
-# set the above script to run as a kdump prescript, which runs just before makedumpfile
-sed -i 's/^\(KDUMP_REQUIRED_PROGRAMS\)=.*$/\1=\"\/sbin\/mount_kdump_overlay.sh\"/' etc/sysconfig/kdump
-sed -i 's/^\(KDUMP_PRESCRIPT\)=.*$/\1=\"\/sbin\/mount_kdump_overlay.sh\"/' etc/sysconfig/kdump
+    # Omit these drivers to make a smaller initrd.
+    kdump_omit_drivers=$OMIT_DRIVERS
+    kdump_omit_drivers+=( "mlx5_core" )
+    kdump_omit_drivers+=( "mlx5_ib" )
+    kdump_omit_drivers+=( "sunrpc" )
+    kdump_omit_drivers+=( "xhci_hcd" )
 
-# Remove the original and create the new kdump initrd with our modified script
-echo "Generating modified kdump initrd..."
-# Remove the existing initrd and replace it with our modified one
-rm -f ${initrd_name}
-find . | cpio -oac | xz -C crc32 -z -c > ${initrd_name}
+    # move the 05-metal.conf file out of the way while the initrd is generated
+    # it causes some conflicts if it's in place when 'dracut' is called.
+    # This is restored by the cleanup function at the end.
+    rm -f /etc/dracut.conf.d/05-metal.conf
 
-popd || exit 1
+    # generate the kdump initrd
+    # Special notes for specific parameters:
+    # - hostonly makes a smaller initrd for the system; if this script is ran in the pipeline this should be swapped for --no-hostonly.
+    # - fstab is used to mitigate risk from reading /proc/mounts
+    # - mount these are given to support mounting both /kdump/boot and /kdump/mnt0, /kdump/boot is meaningless so this is done as a formality
+    # - filesystems only xfs is needed
+    # - no-hostonly-default-device removes auto-resolution of root, this neatens the dracut output
+    # - nohardlink is needed to provide init properly, hardlinking does not work since init exists on a different filesystem
+    # - force-drivers raid1 is necessary to be able to view the raids we have
+    echo "Creating initrd/kernel artifacts ..."
+    dracut \
+        -L 4 \
+        --force \
+        --hostonly \
+        --omit "$(printf '%s' "${kdump_omit[*]}")" \
+        --omit-drivers "$(printf '%s' "${kdump_omit_drivers[*]}")" \
+        --add "$(printf '%s' "${kdump_add[*]}")" \
+        --fstab \
+        --nohardlink \
+        --mount "LABEL=${sqfs_label} /kdump/live xfs ro" \
+        --mount "/kdump/live/${live_dir}/${live_img} /kdump/rootfsbase squashfs ro" \
+        --mount "LABEL=${overlay_label} /kdump/overlay xfs" \
+        --filesystems 'xfs' \
+        --compress 'xz -0 --check=crc32' \
+        --no-hostonly-default-device \
+        --kernel-cmdline "$(printf '%s' "${kdump_cmdline[*]}")" \
+        --persistent-policy by-label \
+        --mdadmconf \
+        --printsize \
+        --force-drivers 'raid1' \
+        ${initrd_name}
 
-check_size ${initrd_name}
+    update_fstab ${initrd_name} ${sqfs_label} ${live_dir}
+    check_size ${initrd_name}
+    
+    # restart kdump to apply the change
+    echo "Restarting kdump ..."
+    systemctl restart kdump
+    echo "Done!"
+}
 
-# restart kdump to apply the change
-echo "Restarting kdump..."
-systemctl restart kdump
-
-cleanup
+build_initrd

--- a/roles/ncn-common-setup/files/srv/cray/scripts/common/dracut-lib.sh
+++ b/roles/ncn-common-setup/files/srv/cray/scripts/common/dracut-lib.sh
@@ -31,6 +31,7 @@ export FORCE_ADD=( "dmsquash-live" "livenet" "mdraid" )
 export INSTALL=( "less" "rmdir" "sgdisk" "vgremove" "wipefs" )
 
 # Kernel Version
+# This won't work well if multiple kernels are installed, this'll return the highest installed which might not what's actually running.
 version_full=$(rpm -q --queryformat "%{VERSION}-%{RELEASE}.%{ARCH}\n" kernel-default)
 version_base=${version_full%%-*}
 version_suse=${version_full##*-}


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: CASMTRIAGE-3591

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->
The overlayFS post-script and fstab were causing problems, this change refactors the kdump script to use straight partitions.

There are some other changes in here that remove some layers that aren't needed, and there are updated hacks.

The hack at present regenerates the initrd and fixes the fstab and the mountpoints for kdump.

The new kdump initrd will result in a dumpfile saved in `/var/crash` after the system reboots.

Example:
```bash
[ 1312.496011] sysrq: Trigger a crash
[ 1312.499435] Kernel panic - not syncing: sysrq triggered crash
[ 1312.505191] CPU: 21 PID: 12670 Comm: bash Kdump: loaded Tainted: G               X    5.3.18-150300.59.76-default #1 SLE15-SP3
[ 1312.516576] Hardware name: Intel Corporation S2600WFT/S2600WFT, BIOS SE5C620.86B.02.01.0012.C0001.070720200218 07/07/2020
[ 1312.527520] Call Trace:
[ 1312.529985]  dump_stack+0x66/0x8b
[ 1312.533309]  panic+0xfe/0x2d7
[ 1312.536286]  ? printk+0x52/0x6e
[ 1312.539438]  sysrq_handle_crash+0x11/0x20
[ 1312.543446]  __handle_sysrq+0x89/0x140
[ 1312.547200]  write_sysrq_trigger+0x2b/0x30
[ 1312.551301]  proc_reg_write+0x39/0x60
[ 1312.554968]  vfs_write+0xad/0x1b0
[ 1312.558285]  ksys_write+0xa1/0xe0
[ 1312.561607]  do_syscall_64+0x5b/0x1e0
[ 1312.565271]  entry_SYSCALL_64_after_hwframe+0x44/0xa9
[ 1312.570321] RIP: 0033:0x7f65e061db13
[ 1312.573901] Code: 0f 1f 80 00 00 00 00 90 90 90 90 90 90 90 90 90 90 90 90 90 90 90 90 64 8b 04 25 18 00 00 00 85 c0 75 14 b8 01 00 00 00 0f 05 <48> 3d 00 f0 ff ff 77 55 f3 c3 0f 1f 00 41 54 55 49 89 d4 53 48 89
[ 1312.592645] RSP: 002b:00007ffd960875d8 EFLAGS: 00000246 ORIG_RAX: 0000000000000001
[ 1312.600209] RAX: ffffffffffffffda RBX: 0000000000000002 RCX: 00007f65e061db13
[ 1312.607343] RDX: 0000000000000002 RSI: 0000563d9c1f28f0 RDI: 0000000000000001
[ 1312.614475] RBP: 0000563d9c1f28f0 R08: 000000000000000a R09: 0000000000000000
[ 1312.621609] R10: 0000563d9cb69460 R11: 0000000000000246 R12: 00007f65e0901500
[ 1312.628739] R13: 0000000000000002 R14: 00007f65e0906c00 R15: 0000000000000002
[    0.114959] [Firmware Bug]: the BIOS has corrupted hw-PMU resources (MSR 38d is b0)
�[    1.910941] mce: Unable to init MCE device (rc: -5)
mount: /kdump/rootfsbase: cannot remount /kdump/live/LiveOS/filesystem.squashfs read-write, is write-protected.
Unable to ioctl(KDSETLED) -- are you not on the console? (Inappropriate ioctl for device)
Nothing to delete in /kdump/overlay/LiveOS/overlay-SQFSRAID-88e1f58f-c052-4f1f-bd91-ca7391e29e29/var/crash.
Extracting dmesg
-------------------------------------------------------------------------------

The dmesg log is saved to /kdump/overlay/LiveOS/overlay-SQFSRAID-88e1f58f-c052-4f1f-bd91-ca7391e29e29/var/crash/2022-06-29-20:23/dmesg.txt.

makedumpfile Completed.
-------------------------------------------------------------------------------
Saving dump using makedumpfile
-------------------------------------------------------------------------------
Copying data                                      : [100.0 %] |           eta: 0s

The dumpfile is saved to /kdump/overlay/LiveOS/overlay-SQFSRAID-88e1f58f-c052-4f1f-bd91-ca7391e29e29/var/crash/2022-06-29-20:23/vmcore.

makedumpfile Completed.
-------------------------------------------------------------------------------
Generating README              Finished.
Copying System.map             Finished.
Copying kernel                 Finished.
```

Here's the resulting dump:
```bash
ncn-w002:~ # ls /var/crash/*
dmesg.txt  README.txt  System.map-5.3.18-150300.59.76-default  vmcore  vmlinux-5.3.18-150300.59.76-default.gz
```

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [x] I have included documentation in my PR (or it is not required)
- [x] I tested this on internal system (if yes, please include results or a description of the test)
- [x] I tested this on a vshasta system (if yes, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
