### PR TITLE
MTL-1735 Migrate setup.sh build steps

### DIFF
--- a/roles/ncn-common-setup/defaults/main.yml
+++ b/roles/ncn-common-setup/defaults/main.yml
@@ -28,4 +28,8 @@ services_metal:
   - name: metal-iptables
     enabled: no
     state: stopped
-    
+cray_dns_servers:
+  - 172.31.84.40
+  - 172.30.84.40
+required_suse_extensions:
+  - sle-module-public-cloud

--- a/roles/ncn-common-setup/tasks/gcp.yml
+++ b/roles/ncn-common-setup/tasks/gcp.yml
@@ -8,12 +8,17 @@
     owner: root
     group: root
     
+- name: backup /etc/sysconfig/network/config
+  copy:
+    src: /etc/sysconfig/network/config
+    dest: /etc/sysconfig/network/config.backup
+    
 - name: use Cray DNS servers at buld-time
   replace:
     path: /etc/sysconfig/network/config
     regexp: '^(NETCONFIG_DNS_STATIC_SERVERS=).*'
     replace: '\1"172.31.84.40 172.30.84.40"'
-  
+
 - name: Restart network
   systemd:
     name: network

--- a/roles/ncn-common-setup/tasks/gcp.yml
+++ b/roles/ncn-common-setup/tasks/gcp.yml
@@ -17,7 +17,7 @@
   replace:
     path: /etc/sysconfig/network/config
     regexp: '^(NETCONFIG_DNS_STATIC_SERVERS=).*'
-    replace: '\1"172.31.84.40 172.30.84.40"'
+    replace: '\1"{{ cray_dns_servers[0] }} {{ cray_dns_servers[1] }}"'
 
 - name: Restart network
   systemd:
@@ -65,10 +65,9 @@
 
 - name: get available suse extensions
   command: /usr/sbin/SUSEConnect --list-extensions
-  register: suse_extensions
-  changed_when: False
+  register: available_suse_extensions
 
-- name: activate suse public cloud module
-  command: /usr/sbin/SUSEConnect -p {{ suse_extensions.stdout | regex_search ('sle-module-public-cloud.*') }}
-  register: module_activation
-  failed_when: module_activation.rc != 0
+- name: activate wanted suse extensions
+  command: /usr/sbin/SUSEConnect -p {{ available_suse_extensions.stdout | regex_search(item + '/.*/.*') }}
+  with_items: "{{ required_suse_extensions }}"
+

--- a/roles/ncn-common-setup/tasks/gcp.yml
+++ b/roles/ncn-common-setup/tasks/gcp.yml
@@ -7,12 +7,12 @@
     mode: '0644'
     owner: root
     group: root
-    
+
 - name: backup /etc/sysconfig/network/config
   copy:
     src: /etc/sysconfig/network/config
     dest: /etc/sysconfig/network/config.backup
-    
+
 - name: use Cray DNS servers at buld-time
   replace:
     path: /etc/sysconfig/network/config

--- a/roles/ncn-common-setup/tasks/gcp.yml
+++ b/roles/ncn-common-setup/tasks/gcp.yml
@@ -1,5 +1,16 @@
 ---
 
+- name: use Cray DNS servers at buld-time
+  replace:
+    path: /etc/sysconfig/network/config
+    regexp: '^(NETCONFIG_DNS_STATIC_SERVERS=).*'
+    replace: '\1"172.31.84.40 172.30.84.40"'
+  
+- name: Restart network
+  systemd:
+    name: network
+    state: restarted
+    
 - name: ensure it is known this is a google system
   file:
     path: /etc/google_system
@@ -46,3 +57,13 @@
     name: "gcp authorized keys"
     minute: "*/1"
     job: "cp /root/.ssh/id_rsa.pub /root/.ssh/authorized_keys >> /var/log/cray/cron.log 2>&1"
+
+- name: get available suse extensions
+  command: /usr/sbin/SUSEConnect --list-extensions
+  register: suse_extensions
+  changed_when: False
+
+- name: activate suse public cloud module
+  command: /usr/sbin/SUSEConnect -p {{ suse_extensions.stdout | regex_search ('sle-module-public-cloud.*') }}
+  register: module_activation
+  failed_when: module_activation.rc != 0

--- a/roles/ncn-common-setup/tasks/gcp.yml
+++ b/roles/ncn-common-setup/tasks/gcp.yml
@@ -1,5 +1,13 @@
 ---
 
+- name: ensure it is known this is a google system
+  file:
+    path: /etc/google_system
+    state: touch
+    mode: '0644'
+    owner: root
+    group: root
+    
 - name: use Cray DNS servers at buld-time
   replace:
     path: /etc/sysconfig/network/config
@@ -10,14 +18,6 @@
   systemd:
     name: network
     state: restarted
-    
-- name: ensure it is known this is a google system
-  file:
-    path: /etc/google_system
-    state: touch
-    mode: '0644'
-    owner: root
-    group: root
 
 - name: install google guest environment packages
   zypper:

--- a/roles/ncn-common-setup/tasks/metal.yml
+++ b/roles/ncn-common-setup/tasks/metal.yml
@@ -17,3 +17,14 @@
     remote_src: yes
     src: /srv/cray/resources/metal/sshd_config
     dest: /etc/ssh/sshd_config
+
+- name: Setup dracut to use fstab.metal
+  lineinfile:
+    path: /etc/dracut.conf.d/05-metal.conf
+    create: yes
+    state: present
+    regexp: '^add_fstab\+\=/etc/fstab\.metal$'
+    line: 'add_fstab+=/etc/fstab.metal'
+
+- name: Execute dracut
+  command: dracut --force

--- a/roles/ncn-common-setup/tasks/metal.yml
+++ b/roles/ncn-common-setup/tasks/metal.yml
@@ -18,7 +18,7 @@
     src: /srv/cray/resources/metal/sshd_config
     dest: /etc/ssh/sshd_config
 
-- name: Setup dracut to use fstab.metal
+- name: Update Dracut to include dynamically created partitions from deployments
   lineinfile:
     path: /etc/dracut.conf.d/05-metal.conf
     create: yes


### PR DESCRIPTION
### Summary and Scope
https://jira-pro.its.hpecorp.net:8443/browse/MTL-1735

Moves the logic from the common layer setup.sh scripts:
- **boxes/ncn-common/provisioners/google/setup.sh** -> **roles/ncn-common-setup/tasks/gcp.yml**
- **boxes/ncn-common/provisioners/metal/setup.sh** -> **roles/ncn-common-setup/tasks/metal.yml**

Note: node-images/boxes/ncn-common/provisioners/common/setup.sh will remain as a shell provisioner because it expands the disk and installs ansible.

#### Issue Type

Ansible migration. 

### Prerequisites

- [x] I have included documentation in my PR (or it is not required)
- [x] I have tested this by building an image using this branch HEAD, or this is does not pertain to the node-images pipeline.
- [x] I tested this on internal system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
- [x] I tested this on a vshasta system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
 
### Idempotency
 
bash script build logic was ported to ansible as idempotently as it can be right now.
