### PR TITLE
MTL-1855

### DIFF
--- a/roles/ncn-common-setup/files/srv/cray/scripts/common/chrony/csm_ntp.py
+++ b/roles/ncn-common-setup/files/srv/cray/scripts/common/chrony/csm_ntp.py
@@ -92,19 +92,18 @@ def get_bss_data(token, xname):
     data = {'name': xname}
     headers = {"Authorization": bearer_token}
     try:
+        # rely on BSS data only and ignore the cloud-init cache
         response = requests.get(endpoint, params=data, headers=headers, verify=False, timeout=5)
-        # If BSS is down, check the local cloud-init cache
         if response.ok:
-            # BSS response has a different structure than the local cache
             try:
                 return response.json()[0]["cloud-init"]["user-data"]
             except KeyError:
-                print("Please validate your BSS data.")
+                print("BSS did not return the expected key. Please validate your BSS data.")
+                print("See "operations/node_management/Configure_NTP_on_NCNs.md#fix-bss-metadata" in the CSM release documentation for steps on validating BSS data.")
                 sys.exit(2)
     except:
-        print("BSS query failed.  Checking local cache...")
-        user_data = get_cache_data(USER_DATA_FILE)
-        return user_data
+        print("BSS query failed. See the error below.")
+        response.raise_for_status()
 
 
 def get_cache_data(filepath):

--- a/roles/ncn-common-setup/files/srv/cray/scripts/common/chrony/csm_ntp.py
+++ b/roles/ncn-common-setup/files/srv/cray/scripts/common/chrony/csm_ntp.py
@@ -106,17 +106,6 @@ def get_bss_data(token, xname):
         response.raise_for_status()
 
 
-def get_cache_data(filepath):
-    """Read the cache file and return the data.
-    @param filepath: string. Specify a path to a file to read.
-    """
-    with open(filepath) as user_data_file:
-        user_data = user_data_file.read()
-    # user-data.txt is in yml, so convert it to json
-    cache_data = yaml.safe_load(user_data)
-    return cache_data
-
-
 def remove_dist_files(confdir=None):
     """Remove *.dist files from the specified path.
     @param confdir: string. Specify a path to a folder to check for *.dist files.

--- a/roles/ncn-common-setup/files/srv/cray/scripts/common/chrony/csm_ntp.py
+++ b/roles/ncn-common-setup/files/srv/cray/scripts/common/chrony/csm_ntp.py
@@ -99,7 +99,7 @@ def get_bss_data(token, xname):
                 return response.json()[0]["cloud-init"]["user-data"]
             except KeyError:
                 print("BSS did not return the expected key. Please validate your BSS data.")
-                print("See "operations/node_management/Configure_NTP_on_NCNs.md#fix-bss-metadata" in the CSM release documentation for steps on validating BSS data.")
+                print("See 'operations/node_management/Configure_NTP_on_NCNs.md#fix-bss-metadata' in the CSM release documentation for steps on validating BSS data.")
                 sys.exit(2)
     except:
         print("BSS query failed. See the error below.")


### PR DESCRIPTION
### Summary and Scope

https://jira-pro.its.hpecorp.net:8443/browse/MTL-1855

- Fixes: MTL-1855

#### Issue Type

- Bugfix Pull Request

Cloud-init local cache is unreliable and should be ignored. csm_ntp.py no longer relies on the cloud-init cache and instead relies only on the BSS data. If BSS is unavailable or the data is bad, csm_ntp.py errors out and points the user documentation.

### Prerequisites

- [x] I have included documentation in my PR (or it is not required)
- [ ] I have tested this by building an image using this branch HEAD, or this is does not pertain to the node-images pipeline.
- [x] I tested this on internal system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
- [ ] I tested this on a vshasta system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
 
### Idempotency
 
Yes
 
### Risks and Mitigations
 
Relying on the cloud-init cache created more issues than it solved. With these changes, users will be required to validate the BSS data before proceeding.

### Failure tests
**Key missing:**
```
BSS did not return the expected key. Please validate your BSS data.
See 'operations/node_management/Configure_NTP_on_NCNs.md#fix-bss-metadata' in the CSM release documentation for steps on validating BSS data.
BSS query failed. See the error below.
Traceback (most recent call last):
  File "./csm_ntp.py", line 184, in <module>
    allow = bss_data["ntp"]["allow"]
```

**Connection to BSS fails**
```
BSS query failed. See the error below.
Traceback (most recent call last):
  File "/usr/lib/python3.6/site-packages/requests/adapters.py", line 449, in send
    timeout=timeout
  File "/usr/lib/python3.6/site-packages/urllib3/connectionpool.py", line 727, in urlopen
    method, url, error=e, _pool=self, _stacktrace=sys.exc_info()[2]
  File "/usr/lib/python3.6/site-packages/urllib3/util/retry.py", line 439, in increment
    raise MaxRetryError(_pool, url, error or ResponseError(cause))
urllib3.exceptions.MaxRetryError: HTTPSConnectionPool(host='test.api-gw-service-nmn.local', port=443): Max retries exceeded with url: /apis/bss/boot/v1/bootparameters?name=x3000c0s1b0n0 (Caused by NewConnectionError('<urllib3.connection.HTTPSConnection object at 0x7f124fcbb748>: Failed to establish a new connection: [Errno -2] Name or service not known',))
```