### PR TITLE
MTL-1841 Missed daemon setup

### DIFF
--- a/roles/ncn-common-setup/files/tests/metal/goss-image-common.yaml
+++ b/roles/ncn-common-setup/files/tests/metal/goss-image-common.yaml
@@ -24,7 +24,7 @@ service:
     enabled: true
     running: true
   metal-iptables.service:
-    enabled: true
+    enabled: false
     running: false
   metalfs.service:
     enabled: true
@@ -33,7 +33,7 @@ service:
     enabled: false
     running: false
   sysstat.service:
-    enabled: false
+    enabled: true
     running: true
   systemd-remount-fs.service:
     enabled: false

--- a/roles/ncn-common-setup/tasks/metal.yml
+++ b/roles/ncn-common-setup/tasks/metal.yml
@@ -22,3 +22,10 @@
   copy:
     src: /srv/cray/resources/metal/dracut.conf.d/
     dest: /etc/dracut.conf.d/
+
+- name: Setup Daemons
+  systemd:
+    name: "{{ item.name }}"
+    enabled: "{{ item.enabled }}"
+    masked: "{{ item.masked | default(false) }}"
+  with_items: "{{ services_metal }}"


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Relates to: MTL-1841

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->
The metal tasks in `ncn-common-setup` were _not_ invoking a task to actually parse `services_metal`. This mean that some services were not starting or stopping as desired.

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I have tested this by building an image using this branch HEAD, or this is does not pertain to the node-images pipeline.
- [ ] I tested this on internal system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
- [ ] I tested this on a vshasta system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
