### PR TITLE
MTL-1858 restore `cloud-init-oneshot.service`

### DIFF
--- a/roles/ncn-common/files/resources/metal/cloud/cloud.cfg.d/05_logging.cfg
+++ b/roles/ncn-common/files/resources/metal/cloud/cloud.cfg.d/05_logging.cfg
@@ -1,48 +1,48 @@
-_log :
-    - &log_base |
-    [loggers]
-    keys=root,cloudinit
+_log:
+ - &log_base |
+   [loggers]
+   keys=root,cloudinit
 
-    [handlers]
-    keys=consoleHandler,cloudLogHandler
+   [handlers]
+   keys=consoleHandler,cloudLogHandler
 
-    [formatters]
-    keys=simpleFormatter,arg0Formatter
+   [formatters]
+   keys=simpleFormatter,arg0Formatter
 
-    [logger_root]
-    level=DEBUG
-    handlers=consoleHandler,cloudLogHandler
+   [logger_root]
+   level=DEBUG
+   handlers=consoleHandler,cloudLogHandler
 
-    [logger_cloudinit]
-    level=DEBUG
-    qualname=cloudinit
-    handlers=
-    propagate=1
+   [logger_cloudinit]
+   level=DEBUG
+   qualname=cloudinit
+   handlers=
+   propagate=1
 
-    [handler_consoleHandler]
-    class=StreamHandler
-    level=WARNING
-    formatter=arg0Formatter
-    args=(sys.stderr,)
+   [handler_consoleHandler]
+   class=StreamHandler
+   level=WARNING
+   formatter=arg0Formatter
+   args=(sys.stderr,)
 
-    [formatter_arg0Formatter]
-    format=%(asctime)s - %(filename)s[%(levelname)s]: %(message)s
+   [formatter_arg0Formatter]
+   format=%(asctime)s - %(filename)s[%(levelname)s]: %(message)s
 
-    [formatter_simpleFormatter]
-    format=[CLOUDINIT] %(filename)s[%(levelname)s]: %(message)s
-    - &log_file |
-    [handler_cloudLogHandler]
-    class=FileHandler
-    level=DEBUG
-    formatter=arg0Formatter
-    args=('/var/log/cloud-init.log',)
-    - &log_syslog |
-    [handler_cloudLogHandler]
-    class=handlers.SysLogHandler
-    level=DEBUG
-    formatter=simpleFormatter
-    args=("/dev/log", handlers.SysLogHandler.LOG_USER)
+   [formatter_simpleFormatter]
+   format=[CLOUDINIT] %(filename)s[%(levelname)s]: %(message)s
+ - &log_file |
+   [handler_cloudLogHandler]
+   class=FileHandler
+   level=DEBUG
+   formatter=arg0Formatter
+   args=('/var/log/cloud-init.log',)
+ - &log_syslog |
+   [handler_cloudLogHandler]
+   class=handlers.SysLogHandler
+   level=DEBUG
+   formatter=simpleFormatter
+   args=("/dev/log", handlers.SysLogHandler.LOG_USER)
 
-log_cfgs :
-    - [ *log_base, *log_file ]
-output : {all: '| tee -a /var/log/cloud-init-output.log'}
+log_cfgs:
+ - [ *log_base, *log_file ]
+output: {all: '| tee -a /var/log/cloud-init-output.log'}

--- a/roles/ncn-common/files/resources/metal/systemd/cloud-init-oneshot.service
+++ b/roles/ncn-common/files/resources/metal/systemd/cloud-init-oneshot.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Run cloud-init init to populate metadata after a shutdown
+After=network-online.target local-fs.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/cloud-init init
+Restart=no
+RemainAfterExit=no
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/ncn-common/tasks/common.yml
+++ b/roles/ncn-common/tasks/common.yml
@@ -121,7 +121,7 @@
   copy:
     remote_src: yes
     src: /srv/cray/resources/common/cloud.cfg
-    dest: /etc/cloud.cfg
+    dest: /etc/cloud/cloud.cfg
 
 - name: Copy motd
   copy:

--- a/roles/ncn-common/vars/metal.yml
+++ b/roles/ncn-common/vars/metal.yml
@@ -36,6 +36,9 @@ services:
   - name: amsd
     enabled: no
     state: stopped
+  - name: cloud-init-oneshot.service
+    enabled: yes
+    state: started
   - name: cpqFca
     enabled: no
     state: stopped


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Relates to: #21 

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->
`cloud.cfg` is in the wrong place, and `cloud-init-oneshot.service` is used and needs to be restored.
### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I have tested this by building an image using this branch HEAD, or this is does not pertain to the node-images pipeline.
- [ ] I tested this on internal system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
- [ ] I tested this on a vshasta system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
