### PR TITLE
MTL-1869 Disable `postfix.service`

### DIFF
--- a/roles/ncn-common/files/tests/common/ncn-common-tests.yml
+++ b/roles/ncn-common/files/tests/common/ncn-common-tests.yml
@@ -53,18 +53,6 @@ service:
   chronyd:
     enabled: true
     running: true
-  cloud-config.service:
-    enabled: true
-    running: true
-  cloud-init.service:
-    enabled: true
-    running: true
-  cloud-init-local.service:
-    enabled: true
-    running: true
-  cloud-final.service:
-    enabled: true
-    running: true
   getty@tty1.service:
     enabled: true
     running: true
@@ -73,6 +61,9 @@ service:
     running: true
   issue-generator:
     enabled: true
+    running: false
+  postfix.service:
+    enabled: false
     running: false
   purge-kernels:
     enabled: true

--- a/roles/ncn-common/vars/common.yml
+++ b/roles/ncn-common/vars/common.yml
@@ -53,6 +53,9 @@ services:
   - name: multi-user.target
     enabled: yes
     state: started
+  - name: postfix.service
+    enabled: no
+    state: stopped
   - name: purge-kernels.service
     enabled: yes
     state: stopped


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: MTL-1869
- Relates to: #21 #22 

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->
Disables `postfix.service`, causing the `You have new mail` notifications to cease.

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [x] I have tested this by building an image using this branch HEAD, or this is does not pertain to the node-images pipeline.
- [ ] I tested this on internal system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
- [ ] I tested this on a vshasta system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
