### PR TITLE
MTL-1872 `setup_uefi_bootorder`

### DIFF
--- a/roles/ncn-common/files/scripts/metal/metal-lib.sh
+++ b/roles/ncn-common/files/scripts/metal/metal-lib.sh
@@ -77,7 +77,7 @@ install_grub2() {
     for disk in $(mdadm --detail $(blkid -L ${boot_authority}) | grep /dev/sd | awk '{print $NF}'); do
         # Add '--suse-enable-tpm' to grub2-install once we need TPM.
         grub2-install --no-rs-codes --suse-force-signed --root-directory $working_path --removable "$disk"
-        efibootmgr -c -D -d "$disk" -p 1 -L "CRAY UEFI OS $index" -l '\efi\boot\bootx64.efi' | grep CRAY
+        efibootmgr -c -D -d "$disk" -p 1 -L "CRAY UEFI OS $index" -l '\efi\boot\bootx64.efi' | grep -i cray
         index=$((index + 1))
     done
 
@@ -357,17 +357,17 @@ EOM
             case $hostname in
                 ncn-m*)
                     efibootmgr | grep -iP '(pxe ipv?(4|6).*adapter)' | tee /tmp/bbs1
-                    efibootmgr | grep cray | tee /tmp/bbs2
+                    efibootmgr | grep -i cray | tee /tmp/bbs2
                     efibootmgr | grep 'UEFI OS' | tee /tmp/bbs3
                     ;;
                 ncn-s*)
                     efibootmgr | grep -iP '(pxe ipv?(4|6).*adapter)' | tee /tmp/bbs1
-                    efibootmgr | grep cray | tee /tmp/bbs2
+                    efibootmgr | grep -i cray | tee /tmp/bbs2
                     efibootmgr | grep 'UEFI OS' | tee /tmp/bbs3
                     ;;
                 ncn-w*)
                     efibootmgr | grep -iP '(pxe ipv?(4|6).*adapter)' | tee /tmp/bbs1
-                    efibootmgr | grep cray | tee /tmp/bbs2
+                    efibootmgr | grep -i cray | tee /tmp/bbs2
                     efibootmgr | grep 'UEFI OS' | tee /tmp/bbs3
                     ;;
                 *)
@@ -386,15 +386,15 @@ EOM
             case $hostname in
                 ncn-m*)
                     efibootmgr | grep -i 'port 1' | grep -i 'pxe ipv4' | tee /tmp/bbs1
-                    efibootmgr | grep cray | tee /tmp/bbs2
+                    efibootmgr | grep -i cray | tee /tmp/bbs2
                     ;;
                 ncn-s*)
                     efibootmgr | grep -i 'port 1' | grep -i 'pxe ipv4' | tee /tmp/bbs1
-                    efibootmgr | grep cray | tee /tmp/bbs2
+                    efibootmgr | grep -i cray | tee /tmp/bbs2
                     ;;
                 ncn-w*)
                     efibootmgr | grep -i 'port 1' | grep -i 'pxe ipv4' | tee /tmp/bbs1
-                    efibootmgr | grep cray | tee /tmp/bbs2
+                    efibootmgr | grep -i cray | tee /tmp/bbs2
                     ;;
                 *)
                     efi_fail_host
@@ -412,15 +412,15 @@ EOM
             case $hostname in
                 ncn-m*)
                     efibootmgr | grep -i 'ipv4' | grep -iv 'baseboard' | tee /tmp/bbs1
-                    efibootmgr | grep -i 'cray' | tee /tmp/bbs2
+                    efibootmgr | grep -i cray | tee /tmp/bbs2
                     ;;
                 ncn-s*)
                     efibootmgr | grep -i 'ipv4' | grep -iv 'baseboard' | tee /tmp/bbs1
-                    efibootmgr | grep -i 'cray' | tee /tmp/bbs2
+                    efibootmgr | grep -i cray | tee /tmp/bbs2
                     ;;
                 ncn-w*)
                     efibootmgr | grep -i 'ipv4' | grep -iv 'baseboard' | tee /tmp/bbs1
-                    efibootmgr | grep -i 'cray' | tee /tmp/bbs2
+                    efibootmgr | grep -i cray | tee /tmp/bbs2
                     ;;
                 *)
                     echo >&2 $0 Unsupported node name $hostname


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: MTL-1872

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->
Fix the empty `/tmp/bbs` files for disk entries by using case-insensitive matching.

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [x] I have tested this by building an image using this branch HEAD, or this is does not pertain to the node-images pipeline.
- [x] I tested this on internal system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
- [ ] I tested this on a vshasta system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
