### PR TITLE
MTL-1871 `cleanup.sh`

### DIFF
--- a/roles/ncn-common/files/scripts/metal/cleanup.sh
+++ b/roles/ncn-common/files/scripts/metal/cleanup.sh
@@ -1,0 +1,115 @@
+#!/bin/bash
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+set -euo pipefail
+
+ALL=0
+AUTO=0
+BASE="$(lsblk -o MOUNTPOINT -nr /dev/disk/by-label/SQFSRAID)"
+DISK="$(blkid -L SQFSRAID)"
+LIVE_DIR=$(grep -oP 'rd.live.dir=[\w\d-_.]+' /proc/cmdline)
+[ -z "$LIVE_DIR" ] && LIVE_DIR='rd.live.dir=LiveOS'
+LIVE_DIR="${LIVE_DIR#*=}"
+
+function usage {
+    cat << EOF
+$0 can be ran with the following:
+
+- Passing any argument other than -y or -a will print this usage.
+- Passing '-y' will automatically clean unused images, bypassing the prompt.
+- Passing '-a' will include all images (unused and used), this will break disk booting unless the node is re-imaged on the next reboot.
+EOF
+}
+
+while getopts "ya" opt; do
+    case ${opt} in
+        y)
+            AUTO=1
+            ;;
+        a)
+            ALL=1
+            ;;
+        *)
+            usage
+    esac
+done
+
+if [ ${ALL} = 0 ]; then
+    readarray -t LIVE_DIRS < <(find /run/initramfs/live/* -type d -exec basename {} \; 2>/dev/null| grep -v ${LIVE_DIR})
+else
+    readarray -t LIVE_DIRS < <(find /run/initramfs/live/* -type d -exec basename {} \; 2>/dev/null)
+fi
+function print_capacity {
+    local capacity
+    local used
+
+    capacity="$(df -h /run/initramfs/live | awk '{print $2}' | sed -z 's/\n/: /g;s/: $/\n/')"
+    used="$(df -h /run/initramfs/live | awk '{print $3}' | sed -z 's/\n/: /g;s/: $/\n/')"
+
+    echo -e "Image storage status:\n\n\t$capacity\n\t$used\n" 
+}
+print_capacity
+echo "Current used image directory is: [${BASE}/${LIVE_DIR}]"
+if [ "${#LIVE_DIRS[@]}" = 0 ]; then
+    echo 'Nothing to remove.'
+    exit 1
+fi
+echo 'Found the following unused image directories: '
+for live_dir in "${LIVE_DIRS[@]}"; do
+    size=$(du -hs ${BASE}/$live_dir | awk '{print $1}')
+    printf '\t%s\t%s\n' ${live_dir} ${size}
+done
+if [ ${AUTO} = 0 ]; then
+    read -r -p "Proceed to cleanup listed image directories? [y/n]:" response
+    case "$response" in
+        [yY][eE][sS]|[yY])
+            echo 'Removing image directories ...'
+            ;;
+        *)
+            echo 'Exiting without removing anything.'
+            exit 0
+            ;;
+    esac
+else
+    echo '-y was present; automatically removing images ...'
+fi
+
+to_remove="$(printf ${BASE}'/%s ' "${LIVE_DIRS[@]}")"
+mount -o rw,remount ${DISK} ${BASE}
+if [ ${ALL} = 1 ]; then
+    echo "-a was present; removing ALL images including the currently booted image [${BASE}/${LIVE_DIR}]"
+    echo >&2 "This node will be unable to diskboot until it is reimaged with a netboot."
+    rm -rf ${to_remove} "${BASE:?}/${LIVE_DIR}"
+else
+    rm -rf ${to_remove}
+fi
+echo 'Done'
+
+# Attempt to remount as ro, but don't fail
+if ! mount -o ro,remount ${DISK} ${BASE} 2>/dev/null; then
+    echo >&2 "Attempted to remount ${BASE} as read-only but the device was busy"
+fi 
+
+# Do not reprint the size, for some reason it doesn't report properly for a given amount of time.
+#print_capacity


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: MTL-1871

#### Issue Type

<!--- Delete un-needed bullets -->

- RFE Pull Request

<!--- words; describe what this change is and what it is for. -->
Adds a `cleanup.sh` script for purging unused or all images from the SQFSRAID.


**Running with no arguments:**
```bash
/srv/cray/scripts/common/cleanup-image-storage.sh
Image storage status:

	Size: 23G
	Used: 15G

Current used image directory is [LiveOS]
Found the following unused image directories:
	1.3.0-alpha.23	4.5G
	1.3.0-alpha.25	4.5G
Proceed to cleanup listed image directories? [y/n]:y
Removing image directories ...
Done
```

**Running with `-y`:**
```bash
Image storage status:

	Size: 23G
	Used: 15G

Current used image directory is: [/run/initramfs/live/1.3.0-alpha.28]
Found the following unused image directories:
	1.3.0-alpha.23	4.5G
	LiveOS	6.0G
Proceed to cleanup listed image directories? [y/n]:y
Removing image directories ...
Done
```

**Running with `-a`:**
```bash
Image storage status:

	Size: 23G
	Used: 15G

Current used image directory is: [/run/initramfs/live/1.3.0-alpha.28]
Found the following unused image directories:
	1.3.0-alpha.23	4.5G
	1.3.0-alpha.28	4.5G
	LiveOS	6.0G
Proceed to cleanup listed image directories? [y/n]:y
Removing image directories ...
-a was present; removing ALL images including the currently booted image [/run/initramfs/live/1.3.0-alpha.28]
This node will be unable to diskboot until it is reimaged with a netboot.
Done
Attempted to remount /run/initramfs/live as read-only but the device was busy
```


Can be automated by invoking it with `-y`.

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [x] I have tested this by building an image using this branch HEAD, or this is does not pertain to the node-images pipeline.
- [x] I tested this on internal system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
- [ ] I tested this on a vshasta system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
