### PR TITLE
CASMINST-4849 Install initrd and kernel

### DIFF
--- a/roles/ncn-common/files/scripts/common/create-ims-initrd.sh
+++ b/roles/ncn-common/files/scripts/common/create-ims-initrd.sh
@@ -24,18 +24,21 @@
 #
 
 # This script does not use bind mounts and thus executes correctly in a container.
-set -e
-set -x
+set -ex
 
 . "$(dirname $0)/dracut-lib.sh"
 
 echo "Generating initrd..."
-
 dracut \
 --force \
 --kver ${KVER} \
 --no-hostonly \
 --no-hostonly-cmdline \
 --printsize
+
+echo "Copying vmlinuz and initrd into /squashfs for disk-bootloader setup."
+rm -f /squashfs/*
+cp -pv /boot/vmlinuz-${KVER} /squashfs/${KVER}.kernel
+cp -pv /boot/initrd-${KVER} /squashfs/initrd.img.xz
 
 exit 0


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Relates to: CASMINST-4849

#### Issue Type

<!--- Delete un-needed bullets -->

- RFE Pull Request

<!--- words; describe what this change is and what it is for. -->
Install the initrd and kernel from the booted squashFS instead of relying on dracut to fetch it.

This is needed for pre-signed URLs to work, because we won't be able to fetch a pre-signed URL for the initrd and kernel during dracut. The pre-signed URL for the initrd and kernel are only available to iPXE.

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I have tested this by building an image using this branch HEAD, or this is does not pertain to the node-images pipeline.
- [ ] I tested this on internal system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
- [ ] I tested this on a vshasta system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
