### PR TITLE
MTL-1905 bad input to `rpm`

### DIFF
--- a/roles/ncn-common/files/tests/common/ncn-common-tests.yml
+++ b/roles/ncn-common/files/tests/common/ncn-common-tests.yml
@@ -46,7 +46,7 @@ command:
   single_kernel:
     exit-status: 0
     # due to pipe, exit status will be zero
-    exec: "rpm -q | grep kernel-default | wc -l"
+    exec: "rpm -q kernel-default | wc -l"
     stdout:
     - 1
     skip: false


### PR DESCRIPTION
The `rpm` command was giving an error:
```bash
rpm -q | grep kernel-default | wc -l
rpm: no arguments given for query
0
```

Changing it from `rpm -qa` to `rpm -q` was done incorrectly, the `grep` needed to be removed. This PR fixes it:

```bash
rpm -q kernel-default | wc -l
1
```