### PR TITLE
MTL-1865 Allow non-root to escalate

### DIFF
--- a/pb_ncn_common.yml
+++ b/pb_ncn_common.yml
@@ -23,6 +23,6 @@
 #
 ---
 - hosts: packer
-  remote_user: root
+  become: yes # Enable builds that do not login as root to escalate privilege.
   roles:
     - ncn-common

--- a/pb_ncn_common_team.yml
+++ b/pb_ncn_common_team.yml
@@ -23,6 +23,6 @@
 #
 ---
 - hosts: packer
-  remote_user: root
+  become: yes # Enable builds that do not login as root to escalate privilege.
   roles:
     - ncn-common-cos


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Relates to: MTL-1865

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->
The current Ansible assumes all builds use `root`, which is untrue when we add builds like Vagrant.

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [x] I have tested this by building an image using this branch HEAD, or this is does not pertain to the node-images pipeline.
- [ ] I tested this on internal system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
- [ ] I tested this on a vshasta system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
