### PR TITLE
MTL-1876 Install initrd and kernel

### DIFF
--- a/roles/ncn-common/files/scripts/common/create-ims-initrd.sh
+++ b/roles/ncn-common/files/scripts/common/create-ims-initrd.sh
@@ -24,18 +24,21 @@
 #
 
 # This script does not use bind mounts and thus executes correctly in a container.
-set -e
-set -x
+set -ex
 
 . "$(dirname $0)/dracut-lib.sh"
 
 echo "Generating initrd..."
-
 dracut \
 --force \
 --kver ${KVER} \
 --no-hostonly \
 --no-hostonly-cmdline \
 --printsize
+
+echo "Copying vmlinuz and initrd into /squashfs for disk-bootloader setup."
+rm -f /squashfs/*
+cp -pv /boot/vmlinuz-${KVER} /squashfs/${KVER}.kernel
+cp -pv /boot/initrd-${KVER} /squashfs/initrd.img.xz
 
 exit 0

--- a/roles/ncn-common/files/scripts/metal/metal-lib.sh
+++ b/roles/ncn-common/files/scripts/metal/metal-lib.sh
@@ -125,7 +125,7 @@ menuentry "$name" --class sles --class gnu-linux --class gnu {
     echo    'Loading kernel ...'
     linuxefi \$prefix/../$disk_cmdline
     echo    'Loading initial ramdisk ...'
-    initrdefi \$prefix/../$INITRD
+    initrdefi \$prefix/../initrd.img.xz
 }
 EOF
 }
@@ -141,29 +141,30 @@ function update_auxiliary_fstab {
     fi
 }
 
+# Gets the boot artifacts and puts them into the bootloader partition.
 function get_boot_artifacts {
-    local squashfs_storage
-    local base_dir
-    local live_dir
-    local working_path
     local artifact_error=0
+    local base_dir=/squashfs # This must copy from /squashfs and not /boot, the initrd at /squashfs is non-hostonly
+    local working_path
 
     mount -L ${boot_authority} -T /etc/fstab.metal && echo 'continuing ...'
     working_path="$(lsblk -o MOUNTPOINT -nr /dev/disk/by-${boot_scheme,,}/${boot_authority})"
     mkdir -pv $working_path/boot
 
-    squashfs_storage=$(grep -Po 'root=\w+:?\w+=\w+' /proc/cmdline | cut -d '=' -f3)
-    [ -z "$squashfs_storage" ] && squashfs_storage=SQFSRAID
-
-    # rd.live.dir - fetched from /proc/cmdline ; grab any customization or deviation from the default preference, aling with dracut.
-    live_dir=$(grep -Eo 'rd.live.dir=.* ' /proc/cmdline | cut -d '=' -f2 | sed 's![^/]$!&/!')
-    [ -z "$live_dir" ] && live_dir=LiveOS/
-
     # pull the loaded items from the mounted squashFS storage into the fallback bootloader
-    base_dir="$(lsblk $(blkid -L $squashfs_storage) -o MOUNTPOINT -n)/$live_dir"
-    [ -d $base_dir ] || echo >&2 'SQFSRAID was not mounted!' return 1
-    cp -pv "${base_dir}kernel" "$working_path/boot/" || echo >&2 "Kernel file NOT found in $base_dir!" || artifact_error=1
-    cp -pv "${base_dir}${INITRD}" "$working_path/boot/" || echo >&2 "${INITRD} file NOT found in $base_dir!" || artifact_error=1
+    . /srv/cray/scripts/common/dracut-lib.sh
+    if [ -z ${KVER} ]; then
+        echo >&2 'Failed to find KVER from /srv/cray/scripts/common/dracut-lib.sh'
+        return 1
+    fi
+    if ! cp -pv ${base_dir}/${KVER}.kernel "$working_path/boot/kernel" ; then
+        echo >&2 "Kernel file NOT found in $base_dir!"
+        artifact_error=1
+    fi
+    if ! cp -pv ${base_dir}/initrd.img.xz "$working_path/boot/initrd.img.xz" ; then
+        echo >&2 "initrd.img.xz file NOT found in $base_dir!"
+        artifact_error=1
+    fi
 
     [ "$artifact_error" = 0 ] && return 0 || return 1
 }


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: MTL-1876
- Relates to: CASMINST-4849

#### Issue Type

<!--- Delete un-needed bullets -->

- RFE Pull Request

<!--- words; describe what this change is and what it is for. -->
Install the initrd and kernel from the booted squashFS instead of relying on dracut to fetch it.

This is needed for pre-signed URLs to work, because we won't be able to fetch a pre-signed URL for the initrd and kernel during dracut. The pre-signed URL for the initrd and kernel are only available to iPXE (and not dracut).

Update the `create-ims-initrd.sh` script to populate `/squashfs` so the bootloader code can grab up-to-date artifacts from IMS builds.

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [x] I have included documentation in my PR (or it is not required)
- [x] I have tested this by building an image using this branch HEAD, or this is does not pertain to the node-images pipeline.
- [x] I tested this on internal system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
