### PR TITLE
MTL-1926 `-t` is incorrect

### DIFF
--- a/roles/ncn-common/files/scripts/metal/metal-lib.sh
+++ b/roles/ncn-common/files/scripts/metal/metal-lib.sh
@@ -61,7 +61,7 @@ install_grub2() {
     local index
     local init_cmdline
     local disk_cmdline
-    mount -v -L ${boot_authority} -t /etc/fstab.metal 2>/dev/null || echo 'already mounted continuing ...'
+    mount -v -L ${boot_authority} -T /etc/fstab.metal 2>/dev/null || echo 'already mounted continuing ...'
     working_path="$(lsblk -o MOUNTPOINT -nr /dev/disk/by-${boot_scheme,,}/${boot_authority})"
 
     # Remove all existing entries; anything with CRAY (lower or uppercase). We


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Relates to: MTL-1926 (discovered while working on MTL-1926 in triage)

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->
In cases where `install_grub2` is invoked by itself as a workaround and if `/metal/recovery` isn't already mounted then the function fails.

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [x] I have tested this by building an image using this branch HEAD, or this is does not pertain to the node-images pipeline.
- [x] I tested this on internal system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
- [ ] I tested this on a vshasta system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
