### PR TITLE
MTL-1930: force-add dmsquash-live

### DIFF
--- a/roles/ncn-common/files/scripts/common/create-ims-initrd.sh
+++ b/roles/ncn-common/files/scripts/common/create-ims-initrd.sh
@@ -31,6 +31,7 @@ set -ex
 echo "Generating initrd..."
 dracut \
 --force \
+--force-add dmsquash-live \
 --kver ${KVER} \
 --no-hostonly \
 --no-hostonly-cmdline \

--- a/roles/ncn-common/files/scripts/common/create-ims-initrd.sh
+++ b/roles/ncn-common/files/scripts/common/create-ims-initrd.sh
@@ -31,7 +31,7 @@ set -ex
 echo "Generating initrd..."
 dracut \
 --force \
---force-add dmsquash-live \
+--force-add "dmsquash-live livenet" \
 --kver ${KVER} \
 --no-hostonly \
 --no-hostonly-cmdline \


### PR DESCRIPTION
### Summary and Scope

Force the dmsquash-live module to be added to the initrd.  Without it, NCNs can't boot.

- Fixes: MTL-1930

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [x] I have included documentation in my PR (or it is not required)
- [x] I have tested this by building an image using this branch HEAD, or this is does not pertain to the node-images pipeline.
- [x] I tested this on internal system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
- [x] I tested this on a vshasta system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
