### PR TITLE
CASMREL-1091 Remove kdump initrd for regen

### DIFF
--- a/roles/ncn-common/files/scripts/common/create-ims-initrd.sh
+++ b/roles/ncn-common/files/scripts/common/create-ims-initrd.sh
@@ -42,4 +42,7 @@ rm -f /squashfs/*
 cp -pv /boot/vmlinuz-${KVER} /squashfs/${KVER}.kernel
 cp -pv /boot/initrd-${KVER} /squashfs/initrd.img.xz
 
+echo "Purging old kdumps initrd; kdump.service will generate a new one on first boot."
+rm -f /boot/initrd-*-kdump
+
 exit 0


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: CASMREL-1091

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->
The old kdump image needs to be purged so that a new one can be regenerated that matches symbols and other details of the new initrd.

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I have tested this by building an image using this branch HEAD, or this is does not pertain to the node-images pipeline.
- [ ] I tested this on internal system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
- [ ] I tested this on a vshasta system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
