### PR TITLE
VSHA-468 Stop setting up `authorized_keys`

### DIFF
--- a/roles/ncn-common/files/scripts/google/cloudinit.sh
+++ b/roles/ncn-common/files/scripts/google/cloudinit.sh
@@ -41,7 +41,3 @@ while ! /etc/ansible/gcp/bin/python3 /srv/cray/scripts/google/update-dns.py; do
   sleep 5
 done
 systemctl restart cron
-# TODO: something is wiping out the authorized_keys file, at least on Virtual Shasta, figure it out
-#       traced it to something in either the update-dns.py above: restarting network services?
-#       or the cron restart above?
-cp /root/.ssh/id_rsa.pub /root/.ssh/authorized_keys


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: VSHA-468

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->
This needs to cease and desist for vshasta to be able to preserve the `authorized_keys` it wants to set up.

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I have tested this by building an image using this branch HEAD, or this is does not pertain to the node-images pipeline.
- [ ] I tested this on internal system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
- [ ] I tested this on a vshasta system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
