### PR TITLE
VSHA-468 `/root/.ssh` does not exist

### DIFF
--- a/roles/ncn-common/files/scripts/google/cloudinit.sh
+++ b/roles/ncn-common/files/scripts/google/cloudinit.sh
@@ -26,6 +26,7 @@
 set -e
 
 echo "Setting up root SSH keys from 'cloud-init' (aka platform metadata)"
+mkdir -p /root/.ssh && chmod 700 /root/.ssh
 craysys metadata get root-private-key > /root/.ssh/id_rsa
 chmod 600 /root/.ssh/id_rsa
 craysys metadata get root-public-key > /root/.ssh/id_rsa.pub

--- a/roles/ncn-common/files/sysctl/common/98-cray-arp.conf
+++ b/roles/ncn-common/files/sysctl/common/98-cray-arp.conf
@@ -1,5 +1,0 @@
-net.ipv4.neigh.default.gc_thresh1 = 2048
-net.ipv4.neigh.default.gc_thresh2 = 4096
-net.ipv4.neigh.default.gc_thresh3 = 8192
-net.ipv4.neigh.default.gc_interval = 30
-net.ipv4.neigh.default.gc_stale_time = 240


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: VSHA-468

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->
This creates `/root/.ssh` for the subsequent commands in `cloudinit.sh` to work.

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I have tested this by building an image using this branch HEAD, or this is does not pertain to the node-images pipeline.
- [ ] I tested this on internal system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
- [ ] I tested this on a vshasta system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
