### PR TITLE
CASMINST-5313 Vagrant systemd services

### DIFF
--- a/roles/ncn-common/tasks/vagrant.yml
+++ b/roles/ncn-common/tasks/vagrant.yml
@@ -22,34 +22,13 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 ---
-- name: Common tasks
-  include_tasks:
-    file: common.yml
-    apply:
-      tags: common
-  tags:
-    - common
-
-- name: Google tasks
-  include_tasks:
-    file: google.yml
-    apply:
-      tags: google
-  tags:
-    - google
-
-- name: Metal tasks
-  include_tasks:
-    file: metal.yml
-    apply:
-      tags: metal
-  tags:
-    - metal
-
-- name: Vagrant tasks
-  include_tasks:
+- include_vars:
     file: vagrant.yml
-    apply:
-      tags: vagrant
-  tags:
-    - vagrant
+
+- name: Setup Daemons
+  systemd:
+    name: "{{ item.name }}"
+    enabled: "{{ item.enabled }}"
+    masked: "{{ item.masked | default(false) }}"
+    state: "{{ item.state }}"
+  loop: "{{ services }}"

--- a/roles/ncn-common/vars/vagrant.yml
+++ b/roles/ncn-common/vars/vagrant.yml
@@ -22,34 +22,10 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 ---
-- name: Common tasks
-  include_tasks:
-    file: common.yml
-    apply:
-      tags: common
-  tags:
-    - common
-
-- name: Google tasks
-  include_tasks:
-    file: google.yml
-    apply:
-      tags: google
-  tags:
-    - google
-
-- name: Metal tasks
-  include_tasks:
-    file: metal.yml
-    apply:
-      tags: metal
-  tags:
-    - metal
-
-- name: Vagrant tasks
-  include_tasks:
-    file: vagrant.yml
-    apply:
-      tags: vagrant
-  tags:
-    - vagrant
+services:
+  - name: cray-heartbeat
+    enabled: no
+    state: stopped
+  - name: spire-agent
+    enabled: no
+    state: stopped


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Relates to: CASMINST-5313

#### Issue Type

<!--- Delete un-needed bullets -->

- RFE Pull Request

<!--- words; describe what this change is and what it is for. -->
Disable systemd services that Dennis is disabling in his `.qcow2` box conversion scripts in the Vagrant OS test harness.

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I have tested this by building an image using this branch HEAD, or this is does not pertain to the node-images pipeline.
- [ ] I tested this on internal system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
- [ ] I tested this on a vshasta system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
