### PR TITLE
MTL-1708 `google-osconfig-agent.service`

### DIFF
--- a/roles/ncn-common/files/tests/google/ncn-common-tests.yml
+++ b/roles/ncn-common/files/tests/google/ncn-common-tests.yml
@@ -25,9 +25,6 @@ service:
   google-guest-agent.service:
     enabled: true
     running: true
-  google-osconfig-agent.service:
-    enabled: true
-    running: true
   google-oslogin-cache.service:
     enabled: true
     running: false

--- a/roles/ncn-common/vars/google.yml
+++ b/roles/ncn-common/vars/google.yml
@@ -26,9 +26,6 @@ services:
   - name: google-guest-agent.service
     enabled: yes
     state: started
-  - name: google-osconfig-agent.service
-    enabled: yes
-    state: started
   - name: google-oslogin-cache.service
     enabled: yes
     state: stopped


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Relates to: MTL-1708

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->
`google-osconfig-agent.service` is no longer instlled in SP4.

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I have tested this by building an image using this branch HEAD, or this is does not pertain to the node-images pipeline.
- [ ] I tested this on internal system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
- [ ] I tested this on a vshasta system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
