### PR TITLE
MTL-2012 Add `livenet`

### DIFF
--- a/roles/node-images-base/files/scripts/common/create-ims-initrd.sh
+++ b/roles/node-images-base/files/scripts/common/create-ims-initrd.sh
@@ -29,7 +29,7 @@ set -ex
 echo "Generating initrd..."
 dracut \
 --force \
---force-add "dmsquash-live livenet" \
+--force-add "$(printf '%s' "${ADD[*]}")" \
 --kver ${KVER} \
 --no-hostonly \
 --no-hostonly-cmdline \

--- a/roles/node-images-base/files/scripts/common/dracut-lib.sh
+++ b/roles/node-images-base/files/scripts/common/dracut-lib.sh
@@ -24,7 +24,7 @@
 # These modules can't exist in the dracut.conf files because they fail on --hostonly builds of dracut,
 # for example when kdump.service runs it uses --hostonly. These modules are necessary when building a
 # PXE bootable initrd, but not for things such as kdump.
-export ADD=( "dmsquash-live" )
+export ADD=( "dmsquash-live" "livenet" )
 
 # Kernel Version
 # This won't work well if multiple kernels are installed, this'll return the highest installed which might not what's actually running.


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Relates to: MTL-2012

#### Issue Type

<!--- Delete un-needed bullets -->

- RFE Pull Request

<!--- words; describe what this change is and what it is for. -->
`livenet` is needed to use URLs with the `root=` argument, this is necessary for application and compute images.

Harmless to include in NCN images, already a part of the NCN IMS rebuilds.

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [x] I have tested this by building an image using this branch HEAD, or this is does not pertain to the node-images pipeline.
- [x] I tested this on internal system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
- [ ] I tested this on a vshasta system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
