### PR TITLE
MTL-1828 Remove default NTP pool

### DIFF
--- a/roles/node-images-base/tasks/common.yml
+++ b/roles/node-images-base/tasks/common.yml
@@ -71,3 +71,14 @@
   synchronize:
     src: /srv/cray/limits/common/
     dest: /etc/security/limits.d/
+
+- name: Remove default NTP pool
+    lineinfile:
+      path: /etc/chrony.conf
+      regexp: '^#?\s*pool\s.*'
+      line: ""
+
+- name: Remove default NTP pool configuration file
+  file:
+    path: /etc/chrony.d/pool.conf
+    state: absent


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: MTL-1828

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request
- Docs Pull Request

<!--- words; describe what this change is and what it is for. -->
Currently our operational docs have users manually remove the default pool from `/etc/chrony.conf`. I noticed that the pool is already commented out by default, but perhaps something comments it back in - either way this change implements the doc step and allows us to remove the doc step.

The JIRA itself also describes the need to remove
`/etc/chrony.d/pool.conf`, this change also removes that file.

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I have tested this by building an image using this branch HEAD, or this is does not pertain to the node-images pipeline.
- [ ] I tested this on internal system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
- [ ] I tested this on a vshasta system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
