### PR TITLE
MTL-1476 Move `create-kis-artifacts.sh` to `metal/`

### DIFF
--- a/roles/node-images-base/files/scripts/metal/cleanup-kis-artifacts.sh
+++ b/roles/node-images-base/files/scripts/metal/cleanup-kis-artifacts.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # MIT License
 #
-# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/roles/node-images-base/files/scripts/metal/create-kis-artifacts.sh
+++ b/roles/node-images-base/files/scripts/metal/create-kis-artifacts.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # MIT License
 #
-# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -31,7 +31,7 @@ function cleanup {
 }
 
 # Source common dracut parameters.
-. "$(dirname $0)/dracut-lib.sh"
+. "$(dirname $0)/../common/dracut-lib.sh"
 
 # This facilitates creating the artifacts in the NCN pipeline.
 mkdir -pv /mnt/squashfs /squashfs


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Relates to: MTL-1476

#### Issue Type

<!--- Delete un-needed bullets -->

- RFE Pull Request

<!--- words; describe what this change is and what it is for. -->
MTL-1476 is adding a new script in `node-images` that requires `create-kis-artifacts.sh`, the new script is for metal only. The `create-kis-artifacts.sh` script technically is also metal only, so to prevent a confusing connection of a metal-only script requiring another metal-only script that lives in `common/` this is moving `create-kis-artifacts.sh` and its cleanup script to `metal/`.

This also updates the copyrights.

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [x] I have tested this by building an image using this branch HEAD, or this is does not pertain to the node-images pipeline.
- [ ] I tested this on internal system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
- [ ] I tested this on a vshasta system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
