### PR TITLE
MTL-1476 Need `ext4`

### DIFF
--- a/roles/node-images-base/files/resources/metal/dracut.conf.d/00-metal.conf
+++ b/roles/node-images-base/files/resources/metal/dracut.conf.d/00-metal.conf
@@ -50,7 +50,7 @@ install_items+=" less rmdir sgdisk vgremove wipefs " # Needs to start and end wi
 mdadmconf="yes"
 
 # Generic options that better align to CSM's usage of the initrd.
-filesystems+=" xfs " # Needs to start and end with a space to mitigate warnings.
+filesystems+=" ext4 xfs " # Needs to start and end with a space to mitigate warnings.
 machine_id="no"
 persistent_policy="by-label"
 ro_mnt="yes"


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Relates to: MTL-1476

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->
The initramFS created for the pre-install-toolkit is lacking the `ext4` module. Adding it to our `dracut.conf.d` will ensure it is included.

Without the module the ext4 OverlayFS fails to load on pre-install-toolkits created by node-images.

```bash
sh-4.4# blkid | grep cow
/dev/sdb3: LABEL="cow" UUID="233b15c2-6c85-4191-906c-69b587eb2ce0" BLOCK_SIZE="4096" TYPE="ext4" PARTLABEL="primary" PARTUUID="df0e7239-138b-4064-9ed2-4deaaba33395"
sh-4.4# mount /dev/sdb3 /mnt
mount: /mnt: unknown filesystem type 'ext4'.
sh-4.4# insmod ext4
insmod: ERROR: could not load module ext4: No such file or directory
```

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I have tested this by building an image using this branch HEAD, or this is does not pertain to the node-images pipeline.
- [x] I tested this on internal system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
- [ ] I tested this on a vshasta system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
