### PR TITLE
VSHA-536 Include `vfat`

### DIFF
--- a/roles/node-images-base/files/resources/metal/dracut.conf.d/00-metal.conf
+++ b/roles/node-images-base/files/resources/metal/dracut.conf.d/00-metal.conf
@@ -50,7 +50,7 @@ install_items+=" less rmdir sgdisk vgremove wipefs " # Needs to start and end wi
 mdadmconf="yes"
 
 # Generic options that better align to CSM's usage of the initrd.
-filesystems+=" ext4 xfs " # Needs to start and end with a space to mitigate warnings.
+filesystems+=" ext4 vfat xfs " # Needs to start and end with a space to mitigate warnings.
 machine_id="no"
 persistent_policy="by-label"
 ro_mnt="yes"


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Relates to: VSHA-536

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->
`vfat` is used by our images, specifically in the disk bootloader. It's automatically included when `create-kis-artifact.sh` is invoked in our build pipeline and on a metal NCN. However it was not included when `create-kis-artifacts.sh` was invoked in vshastav2.

Explicitly including it will ensure it's always included.

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I have tested this by building an image using this branch HEAD, or this is does not pertain to the node-images pipeline.
- [ ] I tested this on internal system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
- [x] I tested this on a vshasta system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
