### PR TITLE
MTL-2077 Add `ll` alias for GNU `ls`

### DIFF
--- a/roles/node-images-base/tasks/common.yml
+++ b/roles/node-images-base/tasks/common.yml
@@ -82,3 +82,13 @@
   file:
     path: /etc/chrony.d/pool.conf
     state: absent
+
+- name: Add ll alias
+  lineinfile:
+    path: /root/.bashrc
+    line: "alias ll='ls -l --color'"
+    owner: root
+    regexp: "^alias ll='.*$"
+    state: present
+    insertafter: EOF
+    create: True


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: MTL-2077

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->

Tested on a running system:

```yaml
---
- hosts: localhost
  tasks:
    - lineinfile:
        path: /root/.bashrc
        line: "alias ll='ls -l --color'"
        owner: root
        regexp: "^alias ll='.*$"
        state: present
        insertafter: EOF
        create: True
```

```bash
ncn-m001:~ # cat .bashrc
source <(kubectl completion bash)
(csm_ansible) ncn-m001:~ # ansible-playbook t.yml
[WARNING]: No inventory was parsed, only implicit localhost is available
[WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'

PLAY [localhost] ***************************************************************************************************************************

TASK [Gathering Facts] *********************************************************************************************************************
ok: [localhost]

TASK [lineinfile] **************************************************************************************************************************
changed: [localhost]

PLAY RECAP *********************************************************************************************************************************
localhost                  : ok=2    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0

(csm_ansible) ncn-m001:~ # cat .bashrc
source <(kubectl completion bash)
alias ll='ls -l --color'
(csm_ansible) ncn-m001:~ # ansible-playbook t.yml
[WARNING]: No inventory was parsed, only implicit localhost is available
[WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'

PLAY [localhost] ***************************************************************************************************************************

TASK [Gathering Facts] *********************************************************************************************************************
ok: [localhost]

TASK [lineinfile] **************************************************************************************************************************
ok: [localhost]

PLAY RECAP *********************************************************************************************************************************
localhost                  : ok=2    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0

(csm_ansible) ncn-m001:~ # source .bashrc
l(csm_ansible) ncn-m001:~ # ll
total 8728
drwxr-xr-x 2 root  root        3 Mar 15  2022 bin
drwxr-xr-x 4 root  root       29 Feb  9 14:12 bklein
drwxr-xr-x 3 root  root     4096 Feb  7 13:45 cd
drwx------ 2 root  root       56 Feb  7 17:37 cfs-configs-comps-backup-20230207_173725-0tF
drwxr-xr-x 4 root  root       57 Feb  2 23:53 inst-sys
drwxrwxrwx 3 root  root       17 Feb  7 16:56 jasons
-rw-r--r-- 1 root  root   970862 Feb  7 21:21 l1
-rw-r--r-- 1 root  root  7940644 Feb  7 21:30 l2
drwxr-xr-x 2 root  root       78 Feb  8 22:14 mbuchmann
-rw-r--r-- 1 root  root        0 Feb  7 16:56 screenlog.0
-rw-r--r-- 1 root  root        0 Feb  7 16:56 screenlog.1
drwx------ 1 spire spire      24 Feb  7 13:28 spire
-rw-r--r-- 1 root  root      203 Feb  8 13:23 testfile
-rw-r--r-- 1 root  root      241 Feb  9 21:23 t.yml
-rwxr--r-- 1 root  root      109 Feb  7 17:37 vcs-creds-helper.sh
-rw-r--r-- 1 root  root      611 Feb  7 16:46 war-CASMNET-1986.2023-02-07.txt
```

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I have tested this by building an image using this branch HEAD, or this is does not pertain to the node-images pipeline.
- [x] I tested this on internal system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
- [ ] I tested this on a vshasta system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
