### PR TITLE
VSHA-536 kdump and cp437

### DIFF
--- a/roles/node-images-base/files/resources/metal/dracut.conf.d/00-metal.conf
+++ b/roles/node-images-base/files/resources/metal/dracut.conf.d/00-metal.conf
@@ -50,7 +50,7 @@ install_items+=" less rmdir sgdisk vgremove wipefs " # Needs to start and end wi
 mdadmconf="yes"
 
 # Generic options that better align to CSM's usage of the initrd.
-filesystems+=" ext4 vfat xfs " # Needs to start and end with a space to mitigate warnings.
+filesystems+=" ext4 fat nls_cp437 nls_iso8859_1 vfat xfs " # Needs to start and end with a space to mitigate warnings.
 machine_id="no"
 persistent_policy="by-label"
 ro_mnt="yes"

--- a/roles/node-images-base/files/scripts/metal/create-kis-artifacts.sh
+++ b/roles/node-images-base/files/scripts/metal/create-kis-artifacts.sh
@@ -65,9 +65,6 @@ if [[ "$1" != "squashfs-only" ]]; then
         --printsize \
         /tmp/initrd.img.xz"
 
-    # Recreate the kdump initrd; this will ensure i    
-    unshare -R /mnt/squashfs bash -c "mkdumprd -K /boot/vmlinuz-${KVER} -I /boot/initrd-${KVER}-kdump -f"
-    
     cp -v /mnt/squashfs/boot/vmlinuz-${KVER} /squashfs/${KVER}.kernel
     cp -v /mnt/squashfs/tmp/initrd.img.xz /squashfs/initrd.img.xz
     rm -f /mnt/squashfs/tmp/initrd.img.xz
@@ -76,7 +73,9 @@ if [[ "$1" != "squashfs-only" ]]; then
     if [ "$(stat -c %d:%i / >/dev/null 2>&1)" != "$(stat -c %d:%i /proc/1/root/. 2>&1 >/dev/null)" ]; then
         echo "Not unmouting dev, proc, run, sys, or var because we're in a chroot."
     else
-          umount -v /mnt/squashfs/dev /mnt/squashfs/proc /mnt/squashfs/run /mnt/squashfs/sys /mnt/squashfs/var
+        # Recreate the kdump initrd; ensure the kdump initrd has parity with the initrd.
+        unshare -R /mnt/squashfs bash -c "mkdumprd -K /boot/vmlinuz-${KVER} -I /boot/initrd-${KVER}-kdump -f"
+        umount -v /mnt/squashfs/dev /mnt/squashfs/proc /mnt/squashfs/run /mnt/squashfs/sys /mnt/squashfs/var
     fi
 fi
 


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: VSHA-536
- Relates to: #74 

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->
- Fix `codepage cp437 not found` errors from development workflows; ensure we always have our necessary modules for all of our filesystems.

    In vshasta, in my dev flow, I am hitting instances where `nls_cp437` is missing.

    Add in the `nls_cp437` code page filesystem, the `fat` FS module, and the `nls_iso8859_1` character set.

    ```
    [  112.731034][ T2076] FAT-fs (md127): codepage cp437 not found
    [  112.729706] dracut-initqueue[2076]: mount: /sysroot: wrong fs type, bad option, bad superblock on /dev/md127, missing codepage or helper program, or other error.
    ```

    I have hit this error before when I was experimenting with `fat` for a `kdump` dumping partition. ![Screenshot_20230214-025828.png](https://user-images.githubusercontent.com/7772179/218687641-b5f2cdf4-9d60-4078-9f99-204552eac76f.png)

- Do not rebuild kdump's initrd in chroot

    When running `create-kis-artifact.sh` in a chroot, a common thing to do when developing on a Cray non-compute node, do not rebuild the kdump initrd.

    The chrooted environment is missing a few mount points that causes the  kdump initrd to build in non-hostonly mode, and in doing so it disregards our request to use the fstab. This results in a kdump initrd that has an unreadable (blank) `/etc/fstab`, preventing a dump from  working:

    ```bash
    [    0.067767][    T1] [Firmware Bug]: the BIOS has corrupted hw-PMU resources (MSR 38d is b0)
    [    4.349296][    T1] mce: Unable to init MCE device (rc: -5)
    Cannot save dump!

      Can't read fstab.

    Something failed. You can try to debug it here.
    Type 'reboot -f' to reboot the system or 'exit' to
    resume the boot process.
    sh-4.4#
    ```

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [x] I have included documentation in my PR (or it is not required)
- [x] I have tested this by building an image using this branch HEAD, or this is does not pertain to the node-images pipeline.
- [x] I tested this on internal system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
- [x] I tested this on a vshasta system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
