### PR TITLE
MTL-2127: ensure the ETCDK8S label exists prior to mounting it

### DIFF
--- a/roles/ncn-common/files/resources/metal/systemd/metalfs.service
+++ b/roles/ncn-common/files/resources/metal/systemd/metalfs.service
@@ -4,6 +4,7 @@ Before=containerd.service etcd.service kubelet.service
 
 [Service]
 Type=oneshot
+ExecStartPre=/bin/bash -c '(while ! /sbin/blkid | grep -q ETCDK8S; do echo "metalfs: waiting for ETCDK8S..."; sleep 2; done);'
 ExecCondition=/bin/bash -c "[ -f /etc/fstab.metal ]"
 ExecStart=/usr/bin/mount -a -T /etc/fstab.metal
 RemainAfterExit=false


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: MTL-2127

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [x] I have included documentation in my PR (or it is not required)
- [x] I have tested this by building an image using this branch HEAD, or this is does not pertain to the node-images pipeline.
- [x] I tested this on internal system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
- [ ] I tested this on a vshasta system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
 