### PR TITLE
MTL-2127: tweak the grep so it works on masters *and* workers

### DIFF
--- a/roles/ncn-common/files/resources/metal/systemd/metalfs.service
+++ b/roles/ncn-common/files/resources/metal/systemd/metalfs.service
@@ -4,7 +4,7 @@ Before=containerd.service etcd.service kubelet.service
 
 [Service]
 Type=oneshot
-ExecStartPre=/bin/bash -c '(while ! /sbin/blkid | grep -q ETCDK8S; do echo "metalfs: waiting for ETCDK8S..."; sleep 2; done);'
+ExecStartPre=/bin/bash -c '(while ! /sbin/blkid | grep -q K8S; do echo "metalfs: waiting for K8S volume..."; sleep 2; done);'
 ExecCondition=/bin/bash -c "[ -f /etc/fstab.metal ]"
 ExecStart=/usr/bin/mount -a -T /etc/fstab.metal
 RemainAfterExit=false


### PR DESCRIPTION
masters have ETCDK8S. workers have K8SLET.  grep for "K8S" to catch both.

### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: MTL-2127

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [x] I have included documentation in my PR (or it is not required)
- [x] I have tested this by building an image using this branch HEAD, or this is does not pertain to the node-images pipeline.
- [x] I tested this on internal system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
- [x] I tested this on a vshasta system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
