### PR TITLE
CASM-3514

### DIFF
--- a/roles/node-images-base/files/scripts/metal/create-kis-artifacts.sh
+++ b/roles/node-images-base/files/scripts/metal/create-kis-artifacts.sh
@@ -94,6 +94,5 @@ if [[ "$1" != "kernel-initrd-only" ]]; then
       -noappend \
       -no-recovery \
       -processors "$(nproc)" \
-      -e /mnt/squashfs/squashfs/filesystem.squashfs \
-      -e /squashfs
+      -e /mnt/squashfs/squashfs/filesystem.squashfs
 fi

--- a/roles/node-images-base/files/scripts/metal/create-kis-artifacts.sh
+++ b/roles/node-images-base/files/scripts/metal/create-kis-artifacts.sh
@@ -65,7 +65,12 @@ if [[ "$1" != "squashfs-only" ]]; then
         --printsize \
         /tmp/initrd.img.xz"
 
-    cp -v /mnt/squashfs/boot/vmlinuz-${KVER} /squashfs/${KVER}.kernel
+    ls -1 "/mnt/squashfs/boot/Image-${KVER}" &> /dev/null && \
+        ARCH_KERNEL="Image-${KVER}" || \
+        ARCH_KERNEL="vmlinuz-${KVER}"
+
+    cp -v /mnt/squashfs/boot/${ARCH_KERNEL} /squashfs/${KVER}.kernel
+
     cp -v /mnt/squashfs/tmp/initrd.img.xz /squashfs/initrd.img.xz
     rm -f /mnt/squashfs/tmp/initrd.img.xz
     chmod 644 /squashfs/initrd.img.xz
@@ -74,12 +79,21 @@ if [[ "$1" != "squashfs-only" ]]; then
         echo "Not unmouting dev, proc, run, sys, or var because we're in a chroot."
     else
         # Recreate the kdump initrd; ensure the kdump initrd has parity with the initrd.
-        unshare -R /mnt/squashfs bash -c "mkdumprd -K /boot/vmlinuz-${KVER} -I /boot/initrd-${KVER}-kdump -f"
+        unshare -R /mnt/squashfs bash -c "mkdumprd -K /boot/${ARCH_KERNEL} -I /boot/initrd-${KVER}-kdump -f"
         umount -v /mnt/squashfs/dev /mnt/squashfs/proc /mnt/squashfs/run /mnt/squashfs/sys /mnt/squashfs/var
     fi
 fi
 
 if [[ "$1" != "kernel-initrd-only" ]]; then
   echo "Creating squashfs artifact"
-  mksquashfs /mnt/squashfs /squashfs/filesystem.squashfs -no-xattrs -comp gzip -no-exports -noappend -no-recovery -processors "$(nproc)" -e /mnt/squashfs/squashfs/filesystem.squashfs
+  mksquashfs /mnt/squashfs \
+      /squashfs/filesystem.squashfs \
+      -no-xattrs \
+      -comp gzip \
+      -no-exports \
+      -noappend \
+      -no-recovery \
+      -processors "$(nproc)" \
+      -e /mnt/squashfs/squashfs/filesystem.squashfs \
+      -e /squashfs
 fi

--- a/roles/node-images-compute/tasks/common.yml
+++ b/roles/node-images-compute/tasks/common.yml
@@ -87,3 +87,4 @@
     enabled: "{{ item.enabled }}"
     masked: "{{ item.masked | default(false) }}"
   loop: "{{ services }}"
+

--- a/roles/node-images-compute/tasks/google.yml
+++ b/roles/node-images-compute/tasks/google.yml
@@ -39,3 +39,67 @@
     enabled: "{{ item.enabled }}"
     masked: "{{ item.masked | default(false) }}"
   loop: "{{ services }}"
+
+#### BEGIN TEMPORARY SECTION ####
+- name: Remove RPMs
+  zypper:
+    name: "{{ item }}"
+    state: absent
+    force: true
+  with_items:
+    - audit
+    - google-osconfig-agent
+    - google-guest-configs
+    - google-opensans-fonts
+    - google-guest-oslogin
+    - python3-google-auth
+    - google-guest-agent
+    - google-opensans-fonts
+    - cloud-regionsrv-client
+    - cloud-regionsrv-client-plugin-gce
+    - cloud-netconfig-gce
+    - python3-gcemetadata
+    - regionServiceClientConfigGCE
+
+- name: Change ownership
+  shell: "find / -path /sys -prune -o -path /proc -prune -o -path /dev -prune -o -path /tmp -prune -o -type d -group 'google-sudoers' -exec chown -R root:root '{}' \\;"
+
+- name: Get users
+  shell: ls -1 /home/
+  register: users_list
+
+- name: Delete users
+  user:
+    name: "{{ item }}"
+    state: absent
+    remove: true
+  loop: "{{ users_list.stdout_lines }}"
+
+- name: Delete google groups
+  group:
+    name: "{{ item }}"
+    state: absent
+  loop:
+    - 'google-sudoers'
+
+- name: sshd remove key only
+  lineinfile:
+    path: /etc/ssh/sshd_config
+    regexp: '.*PasswordAuthentication.*'
+    state: absent
+    create: yes
+
+- name: sshd allow password
+  lineinfile:
+    path: /etc/ssh/sshd_config
+    line: 'PasswordAuthentication yes'
+    state: present
+
+- name: Clear /etc/fstab
+  file:
+    path: /etc/fstab
+    state: "{{ item }}"
+  loop:
+    - absent
+    - touch
+#### END TEMPORARY SECTION ####

--- a/roles/node-images-compute/vars/common.yml
+++ b/roles/node-images-compute/vars/common.yml
@@ -23,9 +23,6 @@
 #
 ---
 services:
-  - name: cfs-state-reporter.service
-    enabled: yes
-    state: stopped
   - name: chronyd.service
     enabled: yes
     state: stopped

--- a/roles/node-images-compute/vars/common.yml
+++ b/roles/node-images-compute/vars/common.yml
@@ -41,4 +41,6 @@ services:
   - name: sshd.service
     enabled: yes
     state: started
-
+#  - name: cfs-state-reporter.service
+#    enabled: yes
+#    state: stopped

--- a/roles/node-images-compute/vars/google.yml
+++ b/roles/node-images-compute/vars/google.yml
@@ -38,3 +38,9 @@ services:
   - name: google-startup-scripts.service
     enabled: yes
     state: stopped
+#  - name: kdump.service
+#    enabled: yes
+#    state: stopped
+#  - name: kdump-early.service
+#    enabled: no
+#    state: stopped

--- a/roles/node-images-compute/vars/google.yml
+++ b/roles/node-images-compute/vars/google.yml
@@ -38,9 +38,3 @@ services:
   - name: google-startup-scripts.service
     enabled: yes
     state: stopped
-  - name: kdump.service
-    enabled: yes
-    state: stopped
-  - name: kdump-early.service
-    enabled: no
-    state: stopped


### PR DESCRIPTION
### Summary and Scope

https://jira-pro.its.hpecorp.net:8443/browse/CASM-3514

#### Issue Type

RFE Pull Request

- ARM support in create-kis-artifacts.sh. The ARM kernel RPM comes with two kernels, one of which has an EFI stub and can be used for PXE booting. create-kis-artifacts.sh needs to select the correct one.
- we are temporarily creating kis artifacts from a google image, so there is a temporary section for compute images to handle that. When we have real ARM runners, we will stop creating our kis artifacts from google images.
- some services were commented out because we don't yet have ARM packages for them


### Prerequisites

- [x] I have included documentation in my PR (or it is not required)
- [x] I have tested this by building an image using this branch HEAD, or this is does not pertain to the node-images pipeline.
- [ ] I tested this on internal system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
- [ ] I tested this on a vshasta system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
 
### Idempotency
 Yes.
