### PR TITLE
CASMINST-4571 pt2

### DIFF
--- a/roles/node-images-ncn-common/tasks/metal.yml
+++ b/roles/node-images-ncn-common/tasks/metal.yml
@@ -75,5 +75,4 @@
     name: "{{ item.name }}"
     enabled: "{{ item.enabled }}"
     masked: "{{ item.masked | default(false) }}"
-    state: "{{ item.state }}"
   loop: "{{ services }}"

--- a/roles/node-images-ncn-common/tasks/vagrant.yml
+++ b/roles/node-images-ncn-common/tasks/vagrant.yml
@@ -30,5 +30,4 @@
     name: "{{ item.name }}"
     enabled: "{{ item.enabled }}"
     masked: "{{ item.masked | default(false) }}"
-    state: "{{ item.state }}"
   loop: "{{ services }}"

--- a/roles/node-images-ncn-common/vars/google.yml
+++ b/roles/node-images-ncn-common/vars/google.yml
@@ -23,6 +23,7 @@
 #
 ---
 required_suse_extensions:
+  - sle-module-server-applications
   - sle-module-public-cloud
 services:
   - enabled: yes

--- a/roles/node-images-ncn-common/vars/google.yml
+++ b/roles/node-images-ncn-common/vars/google.yml
@@ -23,8 +23,8 @@
 #
 ---
 required_suse_extensions:
-  - sle-module-server-applications
   - sle-module-public-cloud
+  - sle-module-server-applications
 services:
   - enabled: yes
     name: google-guest-agent.service


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Relates to: #83 

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->
Some changes made it into the `vendor/` directory instead of the metal-provision repo: https://github.com/Cray-HPE/node-images/pull/718/commits/34f1a581eaa39826347da89c2fa0d64a2804936b#diff-8d9d936a0569c9517bcc3d67a59381e9c45f39560503607883e4305a543906e1

Follow-up PR to #83.

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I have tested this by building an image using this branch HEAD, or this is does not pertain to the node-images pipeline.
- [ ] I tested this on internal system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
- [ ] I tested this on a vshasta system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
