### PR TITLE
Use an upperbound for ceph

### DIFF
--- a/roles/node-images-ncn-common/vars/packages/suse.yml
+++ b/roles/node-images-ncn-common/vars/packages/suse.yml
@@ -26,7 +26,7 @@ packages:
   - amsd=3.3.0-1773.7.sles15
   - apparmor-profiles=3.0.4-150400.5.3.1
   - aws-cli=1.24.4-150200.30.8.1
-  - ceph-common>17
+  - ceph-common<17.2.6
   - conman=0.3.0-150400.9.10
   - cpupower=5.14-150400.3.3.1
   - dracut-metal-mdsquash=2.4.2-1

--- a/roles/node-images-storage-ceph/vars/packages/suse.yml
+++ b/roles/node-images-storage-ceph/vars/packages/suse.yml
@@ -23,7 +23,7 @@
 #
 ---
 packages:
-  - cephadm>17
+  - cephadm<17.2.6
   - golang-github-prometheus-node_exporter=1.3.0-150100.3.20.2
   - libfmt8=8.0.1-150400.1.8
   - ses-release=7-64.1


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Relates to: CASMINST-4571

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->
Artifactory had ceph RPMs for version 16 hiding in the csm-rpms RPM repository, and since that repository had a higher priority than the filesystems-ceph one we had to use the `>` or `>=` operator to force selection of `ceph-17`. However this had a pitfall, now that ceph-17.2.6 is available its packages were being chosen over our desired 17.2.5 RPMs.

We've removed the ceph RPMs from csm-rpms, which were uploaded by Pete a long time ago as an attempted workaround for a CSM tarball. In doing so, using `ceph<17.2.6` now properly resolves 17.2.5 (instead of the old 16.2.9 RPMs).

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I have tested this by building an image using this branch HEAD, or this is does not pertain to the node-images pipeline.
- [ ] I tested this on internal system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
- [ ] I tested this on a vshasta system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
