### PR TITLE
Fix ordering of SUSE modules

### DIFF
--- a/roles/node-images-ncn-common/vars/google.yml
+++ b/roles/node-images-ncn-common/vars/google.yml
@@ -23,8 +23,9 @@
 #
 ---
 required_suse_extensions:
-  - sle-module-public-cloud
+  # Do not sort these A-Z, sometimes these need to be activated in a specific order.
   - sle-module-server-applications
+  - sle-module-public-cloud
 services:
   - enabled: yes
     name: google-guest-agent.service


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Relates to: #91 

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->
The A-Z ordering breaks the registration task:

```bash
Error: Registration server returned 'The product you are attempting to activate (Public Cloud Module 15 SP4 x86_64) requires one of these products to be activated first: Server Applications Module 15 SP4 x86_64' (422)
```
### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I have tested this by building an image using this branch HEAD, or this is does not pertain to the node-images pipeline.
- [ ] I tested this on internal system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
- [ ] I tested this on a vshasta system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
