### PR TITLE
MTL-2092 Use the newer 23.1 cloud-init

### DIFF
--- a/roles/node-images-ncn-common/vars/packages/suse.yml
+++ b/roles/node-images-ncn-common/vars/packages/suse.yml
@@ -73,11 +73,10 @@ packages:
   - cfs-state-reporter=1.9.1-1
   - cfs-trust=1.6.3-1
   # CSM Team
-  # cloud-init: Must use 21.4-1, specifically our forked build in csm-rpms
-  #             MTL-2092 is upgrading to cloud-init-23.
-  - cloud-init-config-suse=21.4-1
-  - cloud-init-doc=21.4-1
-  - cloud-init=21.4-1
+  # cloud-init: Must use 23.1-1, specifically our forked build in csm-rpms
+  - cloud-init-config-suse=23.1-1
+  - cloud-init-doc=23.1-1
+  - cloud-init=23.1-1
   - cray-kubectl-hns-plugin=1.0.1-1
   - cray-kubectl-kubelogin-plugin=1.25.2-1
   - goss-servers=1.16.31-1


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: MTL-2092
- Requires:
- Relates to:

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request
- RFE Pull Request

<!--- words; describe what this change is and what it is for. -->
Our fork now builds 23.1 with our custom cloud-init code. This upgrades us from 21.4 to 23.1, which will appease some of our CVE scans while providing some newer/modern functions.

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I have tested this by building an image using this branch HEAD, or this is does not pertain to the node-images pipeline.
- [ ] I tested this on internal system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
- [ ] I tested this on a vshasta system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
