### PR TITLE
Disable `spire-agent`

### DIFF
--- a/roles/node-images-kubernetes/vars/services/suse.yml
+++ b/roles/node-images-kubernetes/vars/services/suse.yml
@@ -41,6 +41,6 @@ services:
   - enabled: yes
     name: kubelet.service
     state: stopped
-  - enabled: true
+  - enabled: false
     name: spire-agent.service
     state: stopped

--- a/roles/node-images-storage-ceph/vars/services/suse.yml
+++ b/roles/node-images-storage-ceph/vars/services/suse.yml
@@ -38,6 +38,6 @@ services:
   - enabled: true
     name: csm-node-identity.service
     state: stopped
-  - enabled: yes
+  - enabled: false
     name: spire-agent.service
     state: stopped


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: Errors that spire failed to start

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->
`spire-agent` regressed and was enabled when it shouldn't have been. It should only be enabled/started on NCNs when the
`join-spire-on-storage.sh` script is invoked.

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I have tested this by building an image using this branch HEAD, or this is does not pertain to the node-images pipeline.
- [ ] I tested this on internal system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
- [ ] I tested this on a vshasta system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
