### PR TITLE
Add tenant name/id header when scoped to tenant (CASMPET-6319)

### DIFF
--- a/roles/node-images-base/vars/packages/suse.yml
+++ b/roles/node-images-base/vars/packages/suse.yml
@@ -26,7 +26,7 @@ packages:
   - google-guest-configs=20230217.01-150400.21.2
   - google-guest-oslogin=20230217.00-150400.31.3
   # csm
-  - craycli=0.80.1-1
+  - craycli=0.81.0-1
   - csm-node-identity=1.0.20-1
   - spire-agent=1.5.5-1.7
   # user tools


### PR DESCRIPTION
### Summary and Scope

Add tenant configuration option, pass cray-tenant-name header value if specified.

### Issues and Related PRs

* https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-6319

### Testing

Configuration without tenant:

```
ncn-w001:~/.config/cray/configurations # cray init
Overwrite configuration file at: /root/.config/cray/configurations/default ? [y/N]: y
Cray Hostname: https://api-gw-service-nmn.local/
Tenant Name (leave blank for global scope): []:
Username: vers
Password:
Success!

Initialization complete.

ncn-w001:~/.config/cray/configurations # cat default
[core]
hostname = "https://api-gw-service-nmn.local/"
tenant = ""

[auth.login]
username = "vers"
```
Configuration without tenant:

```
ncn-w001:~/.config/cray/configurations # cray init
Overwrite configuration file at: /root/.config/cray/configurations/default ? [y/N]: y
Cray Hostname: https://api-gw-service-nmn.local/
Tenant Name (leave blank for global scope): []: vcluster-red
Username: vers
Password:
Success!

Initialization complete.

ncn-w001:~/.config/cray/configurations # cat default
[core]
hostname = "https://api-gw-service-nmn.local/"
tenant = "vcluster-red"

[auth.login]
username = "vers"
```

Headers without tenant:

```
PUT /token
host: api-gw-service-nmn.local
user-agent: python-requests/2.28.2
accept-encoding: gzip, deflate
accept: */*
```

Headers with tenant:

```
PUT /token
host: api-gw-service-nmn.local
user-agent: python-requests/2.28.2
accept-encoding: gzip, deflate
accept: */*
cray-tenant-name: vcluster-blue <----------- New Header
```

Was a fresh Install tested? N
Was an Upgrade tested?      N - N/A
Was a Downgrade tested?     N - N/A
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

### Risks and Mitigations

Low

### Requires:

* Nothing