### PR TITLE
Missed test refactor

### DIFF
--- a/roles/node-images-ncn-common/files/tests/common/ncn-common-tests.yml
+++ b/roles/node-images-ncn-common/files/tests/common/ncn-common-tests.yml
@@ -77,6 +77,9 @@ service:
   issue-generator:
     enabled: true
     running: false
+  metalfs.service:
+    enabled: true
+    running: false
   postfix.service:
     enabled: false
     running: false

--- a/roles/node-images-ncn-common/files/tests/google/ncn-common-tests.yml
+++ b/roles/node-images-ncn-common/files/tests/google/ncn-common-tests.yml
@@ -37,6 +37,3 @@ service:
   metal-iptables.service:
     enabled: false
     running: false
-  metalfs.service:
-    enabled: false
-    running: false

--- a/roles/node-images-ncn-common/files/tests/metal/ncn-common-tests.yml
+++ b/roles/node-images-ncn-common/files/tests/metal/ncn-common-tests.yml
@@ -55,9 +55,6 @@ service:
   metal-iptables.service:
     enabled: false
     running: false
-  metalfs.service:
-    enabled: true
-    running: false
   smad.service:
     enabled: false
     running: false


### PR DESCRIPTION
The changes from #104 required refactoring the tests for `metalfs` as well.
