### PR TITLE
`cow` not existing during the build causes buildfailure

### DIFF
--- a/roles/node-images-pre-install-toolkit/tasks/main.yml
+++ b/roles/node-images-pre-install-toolkit/tasks/main.yml
@@ -27,15 +27,6 @@
   tags:
     - packages
 
-# kdump reads the fstab to find root, which it uses for writing dumps to.
-# This needs to be a writable partition, such as the overlayFS.
-# ROOTRAID is the overlayFS for most other things, but for the PIT that's the "cow".
-- name: Update fstab for kdump
-  ansible.builtin.replace:
-    path: /etc/fstab
-    regexp: 'ROOTRAID'
-    replace: 'cow'
-
 # TODO: Enable once services exist in vars/services/suse.yml
 #- include_tasks:
 #    file: services.yml


### PR DESCRIPTION
The build will fail with the following message since kdump can't find `cow`:

```
/usr/lib/dracut/modules.d/99kdump/module-setup.sh: line 74: host_fs_types["$_dev"]: bad array subscript
dracut module 'kdump' cannot be found or installed.
```
