### PR TITLE
Add HPC Release function

### DIFF
--- a/scripts/packer/setup-functions.sh
+++ b/scripts/packer/setup-functions.sh
@@ -143,3 +143,27 @@ function setup_legacy_python {
     ln -s "/usr/bin/pip$python_default" /usr/bin/pip3
     ln -s "/usr/bin/python$python_default" /usr/bin/python3 # /usr/bin/python is set by Ansible later.
 }
+
+
+# HPC metal clusters reflect their nature through the SLES HPC Release RPM.
+# The conflicting RPM needs to be removed
+# Forcing the the HPC rpm because removing sles-release auto removes dependencies
+# even with -U when installing with inventory file
+function hpc-release {
+
+    echo "Etching release file"
+    local restore_lock=0
+    if zypper removelock kernel-default; then
+        echo '- removing zypper lock for kernel-default'
+        restore_lock=1
+    fi
+
+    # Needs --force-install in order to remove suse-release if it is present.
+    # Don't PIN this, just install the latest one. If the base image already has this package, then pinning it here will
+    # cause it to be reinstalled (rather pointlessly). This package is really trivial.
+    zypper -n install --auto-agree-with-licenses --force-resolution SLE_HPC-release
+    if [ "$restore_lock" -ne 0 ]; then
+        echo '- restoring zypper lock for kernel-default'
+        zypper addlock kernel-default
+    fi
+}


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

#### Issue Type

<!--- Delete un-needed bullets -->

- RFE Pull Request

<!--- words; describe what this change is and what it is for. -->
Include a function for installing the `SLE_HPC-release` package, fixing any need to duplicate this method in their provisioner blocks.

I want to remove the function [out of ncn-common](https://github.com/Cray-HPE/node-images/blob/main/boxes/ncn-common/provisioners/metal/install.sh#L27-L34) since we install SLE_HPC-release in the base image now ([implicitly](https://github.com/Cray-HPE/node-images/blob/main/boxes/sles15-base/http/autoinst.template.xml#L124)). I want this function because if the implicit install ever ceases, I want a common method for ensuring the RPM is installed.

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I have tested this by building an image using this branch HEAD, or this is does not pertain to the node-images pipeline.
- [ ] I tested this on internal system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
- [ ] I tested this on a vshasta system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
