### PR TITLE
Fix broken comment making invalid Ansible

### DIFF
--- a/roles/node-images-hypervisor/vars/services/debian.yml
+++ b/roles/node-images-hypervisor/vars/services/debian.yml
@@ -21,8 +21,8 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
----#
- NOTE: This list is incomplete, at this time there is no base image for Debian to use as a test.
+---
+# NOTE: This list is incomplete, at this time there is no base image for Debian to use as a test.
 services:
   - enabled: true
     name: libvirtd.service

--- a/roles/node-images-hypervisor/vars/services/rhel.yml
+++ b/roles/node-images-hypervisor/vars/services/rhel.yml
@@ -22,7 +22,6 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 ---
-
 # NOTE: This list is incomplete, at this time there is no base image for RHEL to use as a test.
 services:
   - enabled: true


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Relates to: #114 

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->
The Ansible var file is invalid.
Also fix extra empty line.


I discovered this via the ansible-lint plugin which was ignored in the PR because it's failing all the time. I have an incoming PR to fix the linter so we can actually consider/rely on it.
### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I have tested this by building an image using this branch HEAD, or this is does not pertain to the node-images pipeline.
- [ ] I tested this on internal system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
- [ ] I tested this on a vshasta system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
