### PR TITLE
MTL-2154: Revert aws-cli due to incompatible dependencies

### DIFF
--- a/roles/node-images-ncn-common/vars/packages/suse.yml
+++ b/roles/node-images-ncn-common/vars/packages/suse.yml
@@ -25,7 +25,7 @@
 packages:
   - amsd=3.3.0-1773.7.sles15
   - apparmor-profiles=3.0.4-150400.5.3.1
-  - aws-cli=1.27.115-150400.185.1
+  - aws-cli=1.24.4-150200.30.8.1
   - ceph-common<17.2.6
   - conman=0.3.0-150400.9.10
   - cpupower=5.14-150400.3.3.1


### PR DESCRIPTION
Reverts aws-cli due to missing/incompatible dependencies, including python3-botocore.