### PR TITLE
MTL-2154: Upgrade google-guest-agent

### DIFF
--- a/roles/node-images-base/vars/packages/suse.yml
+++ b/roles/node-images-base/vars/packages/suse.yml
@@ -45,7 +45,7 @@ packages:
   # kdump analysis
   - crash=7.3.0-150400.3.5.8
   # Google Compute
-  - google-guest-agent=20230221.00-150400.39.5
+  - google-guest-agent=20230510.00-150400.40.1
   - google-guest-configs=20230217.01-150400.21.2
   - google-guest-oslogin=20230502.00-150400.32.1
   # csm

--- a/roles/node-images-ncn-common/vars/packages/suse.yml
+++ b/roles/node-images-ncn-common/vars/packages/suse.yml
@@ -25,7 +25,7 @@
 packages:
   - amsd=3.3.0-1773.7.sles15
   - apparmor-profiles=3.0.4-150400.5.3.1
-  - aws-cli=1.27.115-150400.185.1
+  - aws-cli=1.24.4-150200.30.8.1
   - ceph-common<17.2.6
   - conman=0.3.0-150400.9.10
   - cpupower=5.14-150400.3.3.1


### PR DESCRIPTION
Upgrades google-guest-agent due to a break in the build. 