### PR TITLE
CASMCMS-8565 - update ims craycli api to include arch and require-dkms arguments.

### DIFF
--- a/roles/node-images-base/vars/packages/suse.yml
+++ b/roles/node-images-base/vars/packages/suse.yml
@@ -49,7 +49,7 @@ packages:
   - google-guest-configs=20230217.01-150400.21.2
   - google-guest-oslogin=20230502.00-150400.32.1
   # csm
-  - craycli=0.81.0-1
+  - craycli=0.81.1-1
   - csm-node-identity=1.0.20-1
   - spire-agent=1.5.5-1.7
   # user tools


### PR DESCRIPTION
### Summary and Scope

Adds support for arm64 to the IMS cray cli api.

- Fixes: CASMCMS-8565](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8565)

#### Issue Type
- RFE Pull Request

Adds support for arm64 to the IMS cray cli api.

### Prerequisites

- [X] I have included documentation in my PR (or it is not required)
- [X] I have tested this by building an image using this branch HEAD, or this is does not pertain to the node-images pipeline.
- [X] I tested this on internal system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
 
### Idempotency

If this version of the craycli is installed on a system that doesn't have the update IMS service, the existing api will work perfectly fine and the new arguments will just cause failures. 
 
### Risks and Mitigations
 
Low risk