### PR TITLE
CASMCMS-8603: Update cfs-state-reporter

### DIFF
--- a/roles/node-images-application/vars/packages/suse-x86_64.yml
+++ b/roles/node-images-application/vars/packages/suse-x86_64.yml
@@ -23,7 +23,7 @@
 #
 ---
 packages:
-  - cfs-state-reporter=1.9.1-1
+  - cfs-state-reporter=1.9.2-1
   # cloud-init often updates and goes missing in repodata, use `<23.2` to grab 23.1 no matter the release.
   - cloud-init-doc<23.2
 patterns:

--- a/roles/node-images-compute/vars/packages/suse-x86_64.yml
+++ b/roles/node-images-compute/vars/packages/suse-x86_64.yml
@@ -25,7 +25,7 @@
 packages:
   # CMS Team
   - cfs-debugger=1.3.1-1
-  - cfs-state-reporter=1.9.1-1
+  - cfs-state-reporter=1.9.2-1
   - cfs-trust=1.6.3-1
   - bos-reporter=2.1.1-1
   # COS SHASTA-OS packages

--- a/roles/node-images-ncn-common/vars/packages/suse.yml
+++ b/roles/node-images-ncn-common/vars/packages/suse.yml
@@ -70,7 +70,7 @@ packages:
   - xfsdump=3.1.6-1.30
   # CMS Team
   - cfs-debugger=1.3.1-1
-  - cfs-state-reporter=1.9.1-1
+  - cfs-state-reporter=1.9.2-1
   - cfs-trust=1.6.3-1
   # CSM Team
   # cloud-init: Must use 21.4-1, specifically our forked build in csm-rpms


### PR DESCRIPTION
CSM manifests require newest cfs-state-reporter to be updated. New version includes noarch RPM changes for CASMCMS-8603

### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: [CASMCMS-8603](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8603)

#### Issue Type

<!--- Delete un-needed bullets -->

- Feature PR

<!--- words; describe what this change is and what it is for. -->

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I have tested this by building an image using this branch HEAD, or this is does not pertain to the node-images pipeline.
- [ ] I tested this on internal system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
- [ ] I tested this on a vshasta system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations

New cfs-state-reporter rpm is now being built as a `noarch` BuildArch

