### PR TITLE
CASMCMS-8603 cfs-state-reporter is noarch

### DIFF
--- a/roles/node_images_application/vars/packages/suse-x86_64.yml
+++ b/roles/node_images_application/vars/packages/suse-x86_64.yml
@@ -23,7 +23,6 @@
 #
 ---
 packages:
-  - cfs-state-reporter=1.9.2-1
   # cloud-init often updates and goes missing in repodata, use `<23.2` to grab 23.1 no matter the release.
   - cloud-init-doc<23.2
 patterns:

--- a/roles/node_images_application/vars/packages/suse.yml
+++ b/roles/node_images_application/vars/packages/suse.yml
@@ -23,6 +23,7 @@
 #
 ---
 packages:
+  - cfs-state-reporter=1.9.2-1
   # cloud-init often updates and goes missing in repodata, use `<23.2` to grab 23.1 no matter the release.
   - cloud-init-config-suse<23.2
   - cloud-init<23.2

--- a/roles/node_images_compute/vars/packages/suse-x86_64.yml
+++ b/roles/node_images_compute/vars/packages/suse-x86_64.yml
@@ -25,7 +25,6 @@
 packages:
   # CMS Team
   - cfs-debugger=1.3.1-1
-  - cfs-state-reporter=1.9.2-1
   - cfs-trust=1.6.3-1
   - bos-reporter=2.1.1-1
   # COS SHASTA-OS packages

--- a/roles/node_images_compute/vars/packages/suse.yml
+++ b/roles/node_images_compute/vars/packages/suse.yml
@@ -38,6 +38,8 @@ packages:
   - libopenblas_pthreads0=0.3.20-150400.2.3
   - munge=0.5.15-150400.18.3.6
   - typelib-1_0-Gtk-3_0=3.24.34-150400.3.3.1
+  # CMS Team
+  - cfs-state-reporter=1.9.2-1
   # COS General Packages
   # - cray-auth-utils                     :
   # - cray-chrony-dracut                  : NTP setup in dracut


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: CASMCMS-8603
- Relates to: #126 

#### Issue Type

<!--- Delete un-needed bullets -->

- RFE Pull Request

<!--- words; describe what this change is and what it is for. -->
cfs-state-reporter is now noarch and does not need to be listed in the x86_64 only repos.

I missed this in https://github.com/Cray-HPE/metal-provision/pull/126, so this PR is just moving things around.

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I have tested this by building an image using this branch HEAD, or this is does not pertain to the node-images pipeline.
- [ ] I tested this on internal system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
- [ ] I tested this on a vshasta system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
