### PR TITLE
CASMCMS-8604: Updating rpms for bos-reporter

### DIFF
--- a/roles/node_images_compute/vars/packages/suse-x86_64.yml
+++ b/roles/node_images_compute/vars/packages/suse-x86_64.yml
@@ -26,7 +26,7 @@ packages:
   # CMS Team
   - cfs-debugger=1.3.1-1
   - cfs-trust=1.6.3-1
-  - bos-reporter=2.1.1-1
+  - bos-reporter=2.3.0-1
   # COS SHASTA-OS packages
   # - cray-cos-release                    : Installed cle and cos release files.
   - cray-cos-release=1.3.1-2.5_20230113051708__g2c3f0bb


### PR DESCRIPTION
### Summary and Scope

ARM work defined in epic [CASM-4066](https://jira-pro.its.hpecorp.net:8443/browse/CASM-4066) requires that RPMs be built as `noarch` from `x86_64`

- Fixes: [CASMCMS-8604](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8604)
- Relates to: CASMCMS-8517
