### PR TITLE
 MTL-2156: don't bake cray-cmstools-crayctldeploy into the image

### DIFF
--- a/roles/node_images_kubernetes/vars/packages/suse.yml
+++ b/roles/node_images_kubernetes/vars/packages/suse.yml
@@ -27,9 +27,6 @@ packages:
   - ipvsadm=1.29-4.3.1
   - kubeadm=1.21.12-0
   - kubelet=1.21.12-0
-  # CSM
-  - cray-cmstools-crayctldeploy=1.11.11-1
-  - platform-utils=1.5.2-1
   # Metal
   - dracut-metal-dmk8s=2.1.0-1
   - dracut-metal-luksetcd=2.1.0-1


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: MTL-2156

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request
- RFE Pull Request

<!--- words; describe what this change is and what it is for. -->

This PR addresses three issues:
1. Stop baking the cray-cmstools-crayctldeploy rpm into the image - install it via cloud-init
2. Dynamically discover which csm-sle repos are available
3.  Don't `exit 1` when nexus is unavailable.  This is an expected condition during initial NCN deployment.

Tested by copying metal-lib.sh to surtur, sourcing it, and running `install_csm_rpms`:
```
ncn-m001:~/heemstra # install_csm_rpms
install_csm_rpms will search the following repos: csm-sle-15sp4 csm-sle-15sp2 csm-sle-15sp3
Loading repository data...
Reading installed packages...
'cray-cmstools-crayctldeploy = 0:1.10.8-1' is already installed.
No update candidate for 'cray-cmstools-crayctldeploy-1.10.8-1.x86_64'. The highest available version is already installed.
'iuf-cli = 0:1.4.5-1' is already installed.
No update candidate for 'iuf-cli-1.4.5-1.x86_64'. The highest available version is already installed.
'platform-utils = 0:1.4.3-1' is already installed.
No update candidate for 'platform-utils-1.4.3-1.noarch'. The highest available version is already installed.
Resolving package dependencies...

The following 2 packages are going to be upgraded:
  csm-testing goss-servers

The following package is going to be reinstalled:
  canu

The following 3 packages have no support information from their vendor:
  canu csm-testing goss-servers

2 packages to upgrade, 1 to reinstall.
Overall download size: 84.2 MiB. Already cached: 0 B. After the operation, additional 1.0 MiB will be used.
Continue? [y/n/v/...? shows all options] (y): y
Retrieving: canu-1.7.1-2.x86_64 (Plain RPM files cache)                                                                                                                                   (1/3),  84.1 MiB
Retrieving: goss-servers-1.15.45-1.noarch (Plain RPM files cache)                                                                                                                         (2/3),   9.2 KiB
Retrieving: csm-testing-1.15.45-1.noarch (Plain RPM files cache)                                                                                                                          (3/3), 147.8 KiB

Checking for file conflicts: ...........................................................................................................................................................................[done]
(1/3) Installing: canu-1.7.1-2.x86_64 ..................................................................................................................................................................[done]
(2/3) Installing: goss-servers-1.15.45-1.noarch ........................................................................................................................................................[done]
(3/3) Installing: csm-testing-1.15.45-1.noarch .........................................................................................................................................................[done]
There are running programs which still use files and libraries deleted or updated by recent upgrades. They should be restarted to benefit from the latest updates. Run 'zypper ps -s' to list these programs.

ncn-m001:~/heemstra #
```

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [x] I have included documentation in my PR (or it is not required)
- [x] I have tested this by building an image using this branch HEAD, or this is does not pertain to the node-images pipeline.
- [x] I tested this on internal system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
- [x] I tested this on a vshasta system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
