### PR TITLE
MTL-2161 Reformat cloud-init log config file

### DIFF
--- a/roles/node_images_ncn_common/files/metal/cloud/cloud.cfg.d/05_logging.cfg
+++ b/roles/node_images_ncn_common/files/metal/cloud/cloud.cfg.d/05_logging.cfg
@@ -1,48 +1,48 @@
-_log :
-    - &log_base |
+_log:
+  - &log_base |
     [loggers]
     keys=root,cloudinit
-
+    
     [handlers]
     keys=consoleHandler,cloudLogHandler
-
+    
     [formatters]
     keys=simpleFormatter,arg0Formatter
-
+    
     [logger_root]
     level=DEBUG
     handlers=consoleHandler,cloudLogHandler
-
+    
     [logger_cloudinit]
     level=DEBUG
     qualname=cloudinit
     handlers=
     propagate=1
-
+    
     [handler_consoleHandler]
     class=StreamHandler
     level=WARNING
     formatter=arg0Formatter
     args=(sys.stderr,)
-
+    
     [formatter_arg0Formatter]
     format=%(asctime)s - %(filename)s[%(levelname)s]: %(message)s
-
+    
     [formatter_simpleFormatter]
     format=[CLOUDINIT] %(filename)s[%(levelname)s]: %(message)s
-    - &log_file |
+  - &log_file |
     [handler_cloudLogHandler]
     class=FileHandler
     level=DEBUG
     formatter=arg0Formatter
     args=('/var/log/cloud-init.log',)
-    - &log_syslog |
+  - &log_syslog |
     [handler_cloudLogHandler]
     class=handlers.SysLogHandler
     level=DEBUG
     formatter=simpleFormatter
     args=("/dev/log", handlers.SysLogHandler.LOG_USER)
 
-log_cfgs :
-    - [ *log_base, *log_file ]
-output : {all: '| tee -a /var/log/cloud-init-output.log'}
+log_cfgs:
+  - [ *log_base, *log_file ]
+output: { all: '| tee -a /var/log/cloud-init-output.log' }


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: MTL-2161
- Relates to: #121 

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->
The `05_logging.cfg` file was incorrectly formatted and was not in a recognizable YAML structure. This was causing cloud-init to fail configuring its logging, this entailed throwing non-fatal errors and extra log spam into the console.

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I have tested this by building an image using this branch HEAD, or this is does not pertain to the node-images pipeline.
- [x] I tested this on internal system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
- [ ] I tested this on a vshasta system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
