### PR TITLE
CASMINST-6379 New `hpe-yq` package

### DIFF
--- a/roles/node_images_base/vars/packages/suse.yml
+++ b/roles/node_images_base/vars/packages/suse.yml
@@ -79,6 +79,7 @@ packages:
   - git-core=2.35.3-150300.10.27.1
   - gnuplot=5.4.3-150400.1.6
   - hdparm=9.62-150400.1.7
+  - hpe-yq=4.33.3-1
   # Can't install helm-bash-completion due to a conflict with loftsman
   # helm and helm-bash-completion are thus installed only in node_images_hypervisor until that conflict is resolved.
   #  - helm-bash-completion=3.11.2-150000.1.19.1
@@ -143,12 +144,8 @@ packages:
   - vim-data=9.0.1443-150000.5.40.1
   - vim=9.0.1443-150000.5.40.1
   - which=2.21-2.20
-  # TODO:
-  # MTL-2145 Replace hpe-csm-yq-package with yq, yq-bash-completition, and yq-zsh-completion
-  - hpe-csm-yq-package=3.4.1-20210615153837_40f15a6
-#  - yq-bash-completion=4.18.1-bp154.1.17
-#  - yq-zsh-completion=4.18.1-bp154.1.17
-#  - yq=4.18.1-bp154.1.17
+  - yq-bash-completion=4.18.1-bp154.1.17
+  - yq-zsh-completion=4.18.1-bp154.1.17
   - zip=3.0-2.22
   # Python
   - python3-Jinja2=2.10.1-3.10.2

--- a/roles/node_images_ncn_common/vars/packages/suse.yml
+++ b/roles/node_images_ncn_common/vars/packages/suse.yml
@@ -83,7 +83,6 @@ packages:
   - goss-servers=1.16.32-1
   - hpe-csm-goss-package=0.3.21-hpe3
   - hpe-csm-scripts=0.5.5-1
-  - hpe-csm-yq-package=3.4.1-20210615153837_40f15a6
   - loftsman=1.2.0-1
   - manifestgen=1.3.9-1
   # CVT


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: CASMINST-6379

#### Issue Type

<!--- Delete un-needed bullets -->

- RFE Pull Request

<!--- words; describe what this change is and what it is for. -->
Replaces the old, malconfigured `hpe-csm-yq-package` with a new, maintained package. This properly states it provides `yq`, which allows us to install packages dependent on `yq` such as `yq-bash-completion`. The old `hpe-csm-yq-package` provided a `/usr/bin/yq`, `/usr/bin/yq3`, and `/usr/bin/yq4` binary. The new `hpe-yq` package provides the same binaries, but a newer version for `/usr/bin/yq4`.

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I have tested this by building an image using this branch HEAD, or this is does not pertain to the node-images pipeline.
- [x] I tested this on internal system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
- [ ] I tested this on a vshasta system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
