### PR TITLE
CASMPET-6542 New `loftsman` and `helm-bash-completion`

### DIFF
--- a/roles/node_images_base/vars/packages/suse.yml
+++ b/roles/node_images_base/vars/packages/suse.yml
@@ -79,10 +79,10 @@ packages:
   - git-core=2.35.3-150300.10.27.1
   - gnuplot=5.4.3-150400.1.6
   - hdparm=9.62-150400.1.7
+  - helm-bash-completion=3.9.4-150000.1.10.3
+  - helm-zsh-completion=3.9.4-150000.1.10.3
+  - helm=3.9.4-150000.1.10.3
   - hpe-yq=4.33.3-1
-  # Can't install helm-bash-completion due to a conflict with loftsman
-  # helm and helm-bash-completion are thus installed only in node_images_hypervisor until that conflict is resolved.
-  #  - helm-bash-completion=3.11.2-150000.1.19.1
   - htop=3.0.5-bp154.1.30
   - hwloc=2.5.0-150400.1.9
   - iproute2-bash-completion=5.14-150400.1.8

--- a/roles/node_images_ncn_common/vars/packages/suse.yml
+++ b/roles/node_images_ncn_common/vars/packages/suse.yml
@@ -83,7 +83,7 @@ packages:
   - goss-servers=1.16.32-1
   - hpe-csm-goss-package=0.3.21-hpe3
   - hpe-csm-scripts=0.5.5-1
-  - loftsman=1.2.0-1
+  - loftsman=1.2.0-2
   - manifestgen=1.3.9-1
   # CVT
   - cvt=1.4.19-20230502082908_9b144f009c61


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: CASMPET-6542
- Relates to: https://github.com/Cray-HPE/loftsman-rpm/pull/1

#### Issue Type

<!--- Delete un-needed bullets -->

- RFE Pull Request

<!--- words; describe what this change is and what it is for. -->
The new `1.2.0-2` `loftsman` no longer bundles `helm`, which allows us to install the `helm` package (thus making it known to the running Zypper instance). This also enables us to install
`helm-bash-completion`, which requires the `helm` package.

Previously `helm-bash-completion` could not install as it required the `helm `package, but the `helm` package conflicted with `loftsman` due to the bundling.

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I have tested this by building an image using this branch HEAD, or this is does not pertain to the node-images pipeline.
- [x] I tested this on internal system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
- [ ] I tested this on a vshasta system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
