### PR TITLE
Update K8s images for CSM 1.5 to have K8s 1.22 (CASMINST-6374)

### DIFF
--- a/roles/node_images_kubernetes/vars/packages/suse.yml
+++ b/roles/node_images_kubernetes/vars/packages/suse.yml
@@ -25,8 +25,8 @@
 packages:
   - cri-tools=1.25.0-0
   - ipvsadm=1.29-4.3.1
-  - kubeadm=1.21.12-0
-  - kubelet=1.21.12-0
+  - kubeadm=1.22.13-0
+  - kubelet=1.22.13-0
   # Metal
   - dracut-metal-dmk8s=2.1.0-1
   - dracut-metal-luksetcd=2.1.0-1

--- a/roles/node_images_ncn_common/vars/packages/suse.yml
+++ b/roles/node_images_ncn_common/vars/packages/suse.yml
@@ -41,7 +41,7 @@ packages:
   - java-1_8_0-ibm=1.8.0_sr8.0-150000.3.71.1
   - jq=1.6-3.3.1
   - keepalived=2.0.19-bp152.1.9
-  - kubectl=1.21.12-0
+  - kubectl=1.22.13-0
   - lsof=4.91-1.11
   - ltrace=0.7.91-4.3
   - mariadb-tools=10.6.12-150400.3.20.5
@@ -83,6 +83,7 @@ packages:
   - goss-servers=1.16.32-1
   - hpe-csm-goss-package=0.3.21-hpe3
   - hpe-csm-scripts=0.5.5-1
+  - hpe-csm-yq-package=3.4.1-20210615153837_40f15a6
   - loftsman=1.2.0-1
   - manifestgen=1.3.9-1
   # CVT


### PR DESCRIPTION
### Summary and Scope

Update NCN image to K8S v1.22.13

### Issues and Related PRs

* https://jira-pro.its.hpecorp.net:8443/browse/CASM-3290

### Testing

Verified image on redbull:

```
ncn-m002:~ # kubectl get nodes
NAME       STATUS   ROLES                  AGE   VERSION
ncn-m002   Ready    control-plane,master   17h   v1.22.13
ncn-m003   Ready    control-plane,master   17h   v1.22.13
```

Was a fresh Install tested? N
Was an Upgrade tested?      N - N/A
Was a Downgrade tested?     N - N/A
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

### Risks and Mitigations

Low

### Requires:

* Nothing
