### PR TITLE
MTL-2163: platform-utils must remain baked into the image

### DIFF
--- a/roles/node_images_kubernetes/vars/packages/suse.yml
+++ b/roles/node_images_kubernetes/vars/packages/suse.yml
@@ -27,6 +27,10 @@ packages:
   - ipvsadm=1.29-4.3.1
   - kubeadm=1.21.12-0
   - kubelet=1.21.12-0
+  # CSM
+  # platform-utils is also installed by cloud-init. However, we need to *also* bake it in
+  # for proper vshasta-v2 functionality.
+  - platform-utils=1.5.2-1
   # Metal
   - dracut-metal-dmk8s=2.1.0-1
   - dracut-metal-luksetcd=2.1.0-1


### PR DESCRIPTION
### Summary and Scope

CASMPET-6397 requires it.


<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: MTL-2163

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [x] I have included documentation in my PR (or it is not required)
- [x] I have tested this by building an image using this branch HEAD, or this is does not pertain to the node-images pipeline.
- [x] I tested this on internal system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
- [x] I tested this on a vshasta system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
