### PR TITLE
CASMINST-3421 add `noos` repo (CASMINST-6410)

### DIFF
--- a/scripts/repos/cray.template.repos
+++ b/scripts/repos/cray.template.repos
@@ -1,16 +1,16 @@
 # CSM / CLOUD / PET / MTL / NET
-https://${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}@artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-${releasever_major}sp${releasever_minor}?auth=basic                                                   cray-algol60-csm-rpms-stable                      --no-gpgcheck -p 88
-https://${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}@artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3?auth=basic                                                                                      cray-algol60-csm-rpms-stable-sle-15sp3            --no-gpgcheck -p 89
-https://${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}@artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2?auth=basic                                                                                      cray-algol60-csm-rpms-stable-sle-15sp2            --no-gpgcheck -p 90
+https://${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}@artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos?auth=basic                                                                                           cray-algol60-csm-rpms-stable                                                               --no-gpgcheck -p 87
+https://${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}@artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-${releasever_major}sp${releasever_minor}?auth=basic                                                   cray-algol60-csm-rpms-stable-sle-${releasever_major}sp${releasever_minor}                  --no-gpgcheck -p 88
+https://${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}@artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3?auth=basic                                                                                      cray-algol60-csm-rpms-stable-sle-15sp3                                                     --no-gpgcheck -p 89
 
 # SAT
-https://${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}@artifactory.algol60.net/artifactory/sat-rpms/hpe/stable/sle-15sp3?auth=basic                                                                                      cray-algol60-sat-rpms-stable-sle-15sp3            --no-gpgcheck -p 88
+https://${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}@artifactory.algol60.net/artifactory/sat-rpms/hpe/stable/sle-15sp3?auth=basic                                                                                      cray-algol60-sat-rpms-stable-sle-15sp3                                                     --no-gpgcheck -p 88
 
 # COS
-https://${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}@artifactory.algol60.net/artifactory/dst-rpm-mirror/cos-rpm-stable-local/release/cos-2.5/sle${releasever_major}_sp${releasever_minor}_ncn?auth=basic               cray-cos-sle-2.5-SHASTA-OS-cos-ncn                --no-gpgcheck -p 89
+https://${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}@artifactory.algol60.net/artifactory/dst-rpm-mirror/cos-rpm-stable-local/release/cos-2.5/sle${releasever_major}_sp${releasever_minor}_ncn?auth=basic               cray-cos-sle-2.5-SHASTA-OS-cos-ncn                                                         --no-gpgcheck -p 89
 
 # SDU
-https://${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}@artifactory.algol60.net/artifactory/dst-rpm-mirror/sdu-rpm-stable-local/release/img_oci-shasta-2.1/sle15_sp3_ncn?auth=basic                                       sdu-rpm-stable-local                              --no-gpgcheck -p 89
+https://${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}@artifactory.algol60.net/artifactory/dst-rpm-mirror/sdu-rpm-stable-local/release/img_oci-shasta-2.1/sle15_sp3_ncn?auth=basic                                       sdu-rpm-stable-local                                                                       --no-gpgcheck -p 89
 
 # CVT
-https://${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}@artifactory.algol60.net/artifactory/dst-rpm-mirror/csm-diags-rpm-stable-local/release/csm-diags-1.5.0/sle15_sp4?auth=basic                                        csm-diags-sle-15sp4-1.5.0                         --no-gpgcheck -p 89
+https://${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}@artifactory.algol60.net/artifactory/dst-rpm-mirror/csm-diags-rpm-stable-local/release/csm-diags-1.5.0/sle15_sp4?auth=basic                                        csm-diags-sle-15sp4-1.5.0                                                                  --no-gpgcheck -p 89


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: CASMINST-3421
- Requires: https://github.com/Cray-HPE/utils/pull/71
- Relates to: CASMINST-6410

#### Issue Type

<!--- Delete un-needed bullets -->

- RFE Pull Request

<!--- words; describe what this change is and what it is for. -->
This adds the `noos` repository.

CASMINST-6410: `platform-utils` is now available from `sle-15sp4` and `noos`, the `sle-15sp2` repository is no longer needed.
### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I have tested this by building an image using this branch HEAD, or this is does not pertain to the node-images pipeline.
- [ ] I tested this on internal system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
- [ ] I tested this on a vshasta system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
