### PR TITLE
MTL-2032 Add repo groups

### DIFF
--- a/roles/node_images_pre_install_toolkit/vars/packages/suse.yml
+++ b/roles/node_images_pre_install_toolkit/vars/packages/suse.yml
@@ -32,7 +32,7 @@ packages:
   - cray-site-init=1.31.2-1
   - ilorest=3.5.1-1
   - metal-basecamp=1.2.5-1
-  - metal-ipxe=2.4.0-1
+  - metal-ipxe=2.4.1-1
   - pit-init=1.3.1-1
   - pit-nexus=1.2.1-1
   - pit-observability=1.0.6-1

--- a/scripts/nexus/nexus-ssl.conf
+++ b/scripts/nexus/nexus-ssl.conf
@@ -3,7 +3,6 @@
   ProxyRequests Off
   AllowEncodedSlashes NoDecode
   SSLEngine On
-  # FIXME: Do not use sealed secrets cert and key.
   SSLCertificateFile /etc/apache2/ssl.crt/ca.crt
   SSLCertificateKeyFile /etc/apache2/ssl.key/ca.key
   ServerName packages.nmn

--- a/scripts/nexus/setup-nexus.sh
+++ b/scripts/nexus/setup-nexus.sh
@@ -330,9 +330,13 @@ function setup-apache2-https-proxy() {
         return 1
     fi
     "${PITDATA}/prep/site-init/utils/secrets-decrypt.sh" gen_platform_ca_1 \
-    | jq -r '.data."ca_bundle.crt" | @base64d' > /etc/apache2/ssl.crt/ca.crt
+        "${PITDATA}/prep/site-init/certs/sealed_secrets.key" \
+        "${PITDATA}/prep/site-init/customizations.yaml" \
+        | jq -r '.data."ca_bundle.crt" | @base64d' > /etc/apache2/ssl.crt/ca.crt
     "${PITDATA}/prep/site-init/utils/secrets-decrypt.sh" gen_platform_ca_1 \
-    | jq -r '.data."root_ca.key" | @base64d' > /etc/apache2/ssl.key/ca.key
+        "${PITDATA}/prep/site-init/certs/sealed_secrets.key" \
+        "${PITDATA}/prep/site-init/customizations.yaml" \
+        | jq -r '.data."root_ca.key" | @base64d' > /etc/apache2/ssl.key/ca.key
     if [ ! -f /etc/apache2/vhosts.d/nexus-ssl.conf ]; then
         cp -p "$(dirname $0)/nexus-ssl.conf" /etc/apache2/vhosts.d/nexus-ssl.conf
         systemctl restart apache2

--- a/scripts/nexus/setup-nexus.sh
+++ b/scripts/nexus/setup-nexus.sh
@@ -277,7 +277,7 @@ function nexus-get-credential() {
 }
 
 function setup-nexus-server() {
-    set -x
+
     local name
     local repo_name
 


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Relates to: #122 

#### Issue Type

<!--- Delete un-needed bullets -->

- RFE Pull Request

<!--- words; describe what this change is and what it is for. -->
CSM repos usually have the `CSM_RELEASE` (or some dynamic value) in their repo name. Mimmic this in PIT repos, and then use a YUM repo group with a common name for cloud-init to refer to.

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I have tested this by building an image using this branch HEAD, or this is does not pertain to the node-images pipeline.
- [ ] I tested this on internal system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
- [ ] I tested this on a vshasta system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
