### PR TITLE
CASMCSM-8621: Updating cfs-trust to 1.6.4

### DIFF
--- a/roles/node_images_compute/vars/packages/suse-x86_64.yml
+++ b/roles/node_images_compute/vars/packages/suse-x86_64.yml
@@ -26,7 +26,7 @@ packages:
   # CMS Team
   - cfs-debugger=1.3.1-1
   - cfs-state-reporter=1.9.2-1
-  - cfs-trust=1.6.3-1
+  - cfs-trust=1.6.4-1
   # COS SHASTA-OS packages
   # - cray-cos-release                    : Installed cle and cos release files.
   - cray-cos-release=1.3.1-2.5_20230113051708__g2c3f0bb

--- a/roles/node_images_ncn_common/vars/packages/suse.yml
+++ b/roles/node_images_ncn_common/vars/packages/suse.yml
@@ -71,7 +71,7 @@ packages:
   # CMS Team
   - cfs-debugger=1.3.1-1
   - cfs-state-reporter=1.9.2-1
-  - cfs-trust=1.6.3-1
+  - cfs-trust=1.6.4-1
   # CSM Team
   # cloud-init: Must use 21.4-1, specifically our forked build in csm-rpms
   #             MTL-2092 is upgrading to cloud-init-23.


### PR DESCRIPTION
### Summary and Scope

- Fixes: [CASMCMS-8621](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8621)

#### Issue Type

- CSM manifest pr - https://github.com/Cray-HPE/csm/pull/2261

Change updates to latest cfs-trust which publishes noarch rpms.
