### PR TITLE
MTL-2165 and CASMINST-6333

### DIFF
--- a/roles/node_images_pre_install_toolkit/vars/packages/suse.yml
+++ b/roles/node_images_pre_install_toolkit/vars/packages/suse.yml
@@ -30,7 +30,7 @@ packages:
   # CSM
   - canu=1.7.1-2
   - cray-site-init=1.31.2-1
-  - ilorest=3.5.1-1
+  - ilorest=4.2.0.0-20
   - metal-basecamp=1.2.5-1
   - metal-ipxe=2.4.2-1
   - pit-init=1.3.1-1

--- a/roles/node_images_pre_install_toolkit/vars/packages/suse.yml
+++ b/roles/node_images_pre_install_toolkit/vars/packages/suse.yml
@@ -29,7 +29,7 @@ packages:
   - wol=0.7.1-2.5
   # CSM
   - canu=1.7.1-2
-  - cray-site-init=1.31.2-1
+  - cray-site-init=1.31.3-1
   - ilorest=4.2.0.0-20
   - metal-basecamp=1.2.5-1
   - metal-ipxe=2.4.2-1

--- a/scripts/repos/cray.template.repos
+++ b/scripts/repos/cray.template.repos
@@ -1,5 +1,5 @@
 # CSM / CLOUD / PET / MTL / NET
-https://${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}@artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos?auth=basic                                                                                           cray-algol60-csm-rpms-stable                                                               --no-gpgcheck -p 87
+https://${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}@artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos?auth=basic                                                                                           cray-algol60-csm-rpms-stable-noos                                                          --no-gpgcheck -p 87
 https://${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}@artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-${releasever_major}sp${releasever_minor}?auth=basic                                                   cray-algol60-csm-rpms-stable-sle-${releasever_major}sp${releasever_minor}                  --no-gpgcheck -p 88
 https://${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}@artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3?auth=basic                                                                                      cray-algol60-csm-rpms-stable-sle-15sp3                                                     --no-gpgcheck -p 89
 


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: CASMINST-6333 and MTL-2165

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request
- RFE Pull Request

<!--- words; describe what this change is and what it is for. -->
- New ilorest:  
- New cray-site-init: https://github.com/Cray-HPE/cray-site-init/pull/310/files
### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I have tested this by building an image using this branch HEAD, or this is does not pertain to the node-images pipeline.
- [ ] I tested this on internal system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
- [ ] I tested this on a vshasta system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
