### PR TITLE
repo priority, disable gpg check, version update

### DIFF
--- a/roles/node_images_base/vars/packages/suse.yml
+++ b/roles/node_images_base/vars/packages/suse.yml
@@ -45,7 +45,7 @@ packages:
   # kdump analysis
   - crash=7.3.0-150400.3.5.8
   # Google Compute
-  - google-guest-agent=20230510.00-150400.40.2
+  - google-guest-agent=20230601.00-150400.41.1
   - google-guest-configs=20230217.01-150400.21.2
   - google-guest-oslogin=20230502.00-150400.33.1
   # csm

--- a/roles/node_images_compute/vars/packages/suse-aarch64.yml
+++ b/roles/node_images_compute/vars/packages/suse-aarch64.yml
@@ -27,9 +27,7 @@ packages:
   # - cray-cos-release                    : Installed cle and cos release files.
   - cray-cos-release=1.3.1-2.5_20230113051829__g2c3f0bb
   # COS SHASTA-3RD Packages
-  # - acpid                               :
   # - cray-rasdaemon                      :
-  - acpid=2.0.31-1.1_2.5_20230113012842__g40880b3
   - cray-rasdaemon=0.6.8-3_2.5_20230113033939__g9c01752
   # COS General Packages
   # These COS RPM package names vary by timestamp between architectures

--- a/roles/node_images_compute/vars/packages/suse-x86_64.yml
+++ b/roles/node_images_compute/vars/packages/suse-x86_64.yml
@@ -31,11 +31,9 @@ packages:
   # - cray-cos-release                    : Installed cle and cos release files.
   - cray-cos-release=1.3.1-2.5_20230113051708__g2c3f0bb
   # COS SHASTA-3RD Packages
-  # - acpid                               :
   # - cray-libhugetlbfs                   :
   # - cray-libhugetlbfs-devel             :
   # - cray-rasdaemon                      :
-  - acpid=2.0.31-1.1_2.5_20230113012845__g40880b3
   - cray-libhugetlbfs=2.20_2.1.28-2.5_1.9__g814a27a.shasta
   - cray-libhugetlbfs-devel=2.20_2.1.28-2.5_1.9__g814a27a.shasta
   - cray-rasdaemon=0.6.8-3_2.5_20230112191741__g9c01752

--- a/roles/node_images_compute/vars/packages/suse.yml
+++ b/roles/node_images_compute/vars/packages/suse.yml
@@ -26,6 +26,7 @@ packages:
   - java-11-openjdk-devel=11.0.18.0-150000.3.93.1
   # CSM Team
   - csm-auth-utils=1.0.0-1
+  - acpid=2.0.31-2.0
   # CMS Team
   - bos-reporter=2.3.0-1
   # CDST GUI Packages

--- a/scripts/repos/compute.template.repos
+++ b/scripts/repos/compute.template.repos
@@ -1,2 +1,2 @@
 # COS
-https://${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}@artifactory.algol60.net/artifactory/dst-rpm-mirror/cos-rpm-stable-local/release/cos-2.5/sle${releasever_major}_sp${releasever_minor}_cn?auth=basic               cray-cos-2.5-SHASTA-OS-cos-cn               --no-gpgcheck -p 79
+https://${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}@artifactory.algol60.net/artifactory/dst-rpm-mirror/cos-rpm-stable-local/release/cos-2.5/sle${releasever_major}_sp${releasever_minor}_cn?auth=basic               cray-cos-2.5-SHASTA-OS-cos-cn               --no-gpgcheck -p 89

--- a/scripts/repos/suse.template.repos
+++ b/scripts/repos/suse.template.repos
@@ -79,7 +79,7 @@ https://${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}@artifactory.algol60.net/artifac
 https://${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}@artifactory.algol60.net/artifactory/opensuse-mirror/filesystems:ceph:quincy:upstream/openSUSE_Leap_${releasever}?auth=basic                                              filesystems-ceph                                        -g -p 89
 
 # cloud-init
-https://${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}@artifactory.algol60.net/artifactory/opensuse-mirror/Cloud:Tools/SLE_${releasever_major}_SP${releasever_minor}/?auth=basic                                                openSUSE-CloudTools-SLE                                 -g -p 89
+https://${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}@artifactory.algol60.net/artifactory/opensuse-mirror/Cloud:Tools/SLE_${releasever_major}_SP${releasever_minor}/?auth=basic                                                openSUSE-CloudTools-SLE                                 -G -p 89
 
 # free range routing
 https://${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}@artifactory.algol60.net/artifactory/opensuse-mirror/network/${releasever_major}.${releasever_minor}/?auth=basic                                                          openSUSE-network-SLE                                    -g -p 89


### PR DESCRIPTION
### Summary and Scope

- lower COS repo priority to match csm-rpms
- temporarily disable gpg check on opensuse Cloud:Tools repo
- update google-guest-agent version

#### Issue Type


- Bugfix Pull Request

### Prerequisites

- [x] I have included documentation in my PR (or it is not required)
- [x] I have tested this by building an image using this branch HEAD, or this is does not pertain to the node-images pipeline.
- [x] I tested this on internal system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
- [x] I tested this on a vshasta system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
