### PR TITLE
MTL-2169 - re-enable gpg check Cloud:Tools

### DIFF
--- a/scripts/repos/suse.template.repos
+++ b/scripts/repos/suse.template.repos
@@ -79,7 +79,7 @@ https://${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}@artifactory.algol60.net/artifac
 https://${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}@artifactory.algol60.net/artifactory/opensuse-mirror/filesystems:ceph:quincy:upstream/openSUSE_Leap_${releasever}?auth=basic                                              filesystems-ceph                                        -g -p 89
 
 # cloud-init
-https://${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}@artifactory.algol60.net/artifactory/opensuse-mirror/Cloud:Tools/SLE_${releasever_major}_SP${releasever_minor}/?auth=basic                                                openSUSE-CloudTools-SLE                                 -G -p 89
+https://${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}@artifactory.algol60.net/artifactory/opensuse-mirror/Cloud:Tools/SLE_${releasever_major}_SP${releasever_minor}/?auth=basic                                                openSUSE-CloudTools-SLE                                 -g -p 89
 
 # free range routing
 https://${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}@artifactory.algol60.net/artifactory/opensuse-mirror/network/${releasever_major}.${releasever_minor}/?auth=basic                                                          openSUSE-network-SLE                                    -g -p 89


### PR DESCRIPTION
### Summary and Scope

gpg check was disabled on opensuse Cloud:Tools repo. re-enabling gpg check
- Fixes: https://jira-pro.it.hpe.com:8443/browse/MTL-2169

#### Issue Type

- Bugfix Pull Request

### Prerequisites

- [x] I have included documentation in my PR (or it is not required)
- [x] I have tested this by building an image using this branch HEAD, or this is does not pertain to the node-images pipeline.
- [x] I tested this on internal system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
- [x] I tested this on a vshasta system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
 