### PR TITLE
google-guest-agent version backport 1.5

### DIFF
--- a/roles/node_images_base/vars/packages/suse.yml
+++ b/roles/node_images_base/vars/packages/suse.yml
@@ -45,7 +45,7 @@ packages:
   # kdump analysis
   - crash=7.3.0-150400.3.5.8
   # Google Compute
-  - google-guest-agent=20230601.00-150400.41.1
+  - google-guest-agent=20230601.00-150400.42.1
   - google-guest-configs=20230217.01-150400.21.2
   - google-guest-oslogin=20230502.00-150400.33.1
   # csm


### PR DESCRIPTION
### Summary and Scope

- another another google-guest-agent version update