### PR TITLE
Change craycli to use shasta keycloak client instead of deprecated cray client (CASMPET-6640)

### DIFF
--- a/roles/node_images_base/vars/packages/suse.yml
+++ b/roles/node_images_base/vars/packages/suse.yml
@@ -49,7 +49,7 @@ packages:
   - google-guest-configs=20230217.01-150400.21.2
   - google-guest-oslogin=20230502.00-150400.33.1
   # csm
-  - craycli=0.81.2-1
+  - craycli=0.82.1-1
   - csm-auth-utils=1.0.0-1
   - csm-node-identity=1.0.20-1
   - spire-agent=1.5.5-1.7


### PR DESCRIPTION
### Summary and Scope

Switch craycli from deprecated keycloak client

### Issues and Related PRs

* https://jira-pro.it.hpe.com:8443/browse/CASMPET-6640

### Testing

Tested on ashton during MT OPA demo

Was a fresh Install tested? N
Was an Upgrade tested?      N - N/A
Was a Downgrade tested?     N - N/A
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

### Risks and Mitigations

Low

### Requires:

* Nothing
