### PR TITLE
Downgrade back to SLE google-guest packages

### DIFF
--- a/roles/node_images_base/vars/packages/suse.yml
+++ b/roles/node_images_base/vars/packages/suse.yml
@@ -45,9 +45,9 @@ packages:
   # kdump analysis
   - crash=7.3.0-150400.3.5.8
   # Google Compute
-  - google-guest-agent=20230601.00-150400.42.1
-  - google-guest-configs=20230217.01-150400.21.2
-  - google-guest-oslogin=20230502.00-150400.33.1
+  - google-guest-agent=20230221.00-150000.1.34.1
+  - google-guest-configs=20220211.00-150400.13.3.1
+  - google-guest-oslogin=20220721.00-150000.1.30.1
   # csm
   - craycli=0.82.1-1
   - csm-auth-utils=1.0.0-1


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->
The google-guest packages have inadvertently changed vendor to the openSUSE variant. The openSUSE variant changes too frequently, this is causing headaches in node-image builds and CSM tarball creation.

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I have tested this by building an image using this branch HEAD, or this is does not pertain to the node-images pipeline.
- [ ] I tested this on internal system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
- [ ] I tested this on a vshasta system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
