### PR TITLE
MTL-2170 New QLogic 8.72.4.1 Driver

### DIFF
--- a/roles/node_images_base/vars/packages/suse-x86_64.yml
+++ b/roles/node_images_base/vars/packages/suse-x86_64.yml
@@ -31,7 +31,7 @@ packages:
   - grub2-x86_64-efi=2.06-150400.11.30.1
   # Drivers
   - kernel-mft-mlnx-kmp-default=4.21.0_k5.14.21_150400.22-1.sles15sp4
-  - qlgc-fastlinq-kmp-default=8.72.1.0_k5.14.21_150400.22-1.sles15sp4
+  - qlgc-fastlinq-kmp-default=8.72.4.1_k5.14.21_150400.22-1.sles15sp4
   # User tools
   # mft: DO NOT INSTALL MFT FROM THE SPP REPO, NEVER APPEND "slesXspY"
   - ipmitool=1.8.19.gb7c0d66-0


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: MTL-2170
- Relates to: CASMTRIAGE-5033

#### Issue Type

<!--- Delete un-needed bullets -->

- RFE Pull Request

<!--- words; describe what this change is and what it is for. -->
QLogic has requested that we pull in their latest driver and soak it for the CASMTRIAGE-5033 issue.

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I have tested this by building an image using this branch HEAD, or this is does not pertain to the node-images pipeline.
- [ ] I tested this on internal system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
- [ ] I tested this on a vshasta system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
