### PR TITLE
Adds `pulumi` with spice support

### DIFF
--- a/roles/node_images_hypervisor/vars/packages/suse.yml
+++ b/roles/node_images_hypervisor/vars/packages/suse.yml
@@ -42,7 +42,9 @@ packages:
   - libxslt-tools=1.1.34-150400.3.3.1
   - mkisofs=3.02~a09-4.6.1
   - nfs-kernel-server=2.1.1-150100.10.32.1
+  - pulumi-3.73.0-2
   - qemu-kvm=6.2.0-150400.37.14.2
+  - qemu-ui-spice-core=6.2.0-150400.37.14.2
   - supportutils-plugin-cloud-init=1.1-150400.1.5
   - terraform=0.13.4-6.3.1
 patterns:


### PR DESCRIPTION
Installs `pulumi`, an infrastructure as code application for manageing VM deployments. This application requires `python310` and `go1.20`; the former is already installed in our image, the latter is now installed alongside `pulumi`.

Also includes `qemu-ui-spice-core`, a needed dependency for setting up monitors on the VMs. This dependency fixes the `spice support is disabled` error. 

### Tests:

**Failure** (no `qemu-ui-spice-core`)
```bash
hypervisor:~/manderson/sles-development-box/Development/pulumi # pulumi up
Previewing update (kubernetes-cluster):
     Type                     Name                                     Plan
     pulumi:pulumi:Stack      libvirt-py-vm-kubernetes-cluster
 +   ├─ libvirt:index:Domain  libvirt-ex-kubernetes-cluster-vm-0       create
 +   ├─ libvirt:index:Domain  libvirt-ex-kubernetes-cluster-vm-1       create
 +   ├─ libvirt:index:Domain  libvirt-ex-kubernetes-cluster-vm-ubuntu  create
 +   └─ libvirt:index:Domain  libvirt-ex-kubernetes-cluster-vm-2       create


Outputs:
  + libvirt VM 0 name         : "libvirt-ex-kubernetes-cluster-vm-0-3af715a"
  + libvirt VM 1 name         : "libvirt-ex-kubernetes-cluster-vm-1-b5f392d"
  + libvirt VM 2 name         : "libvirt-ex-kubernetes-cluster-vm-2-51b9553"
  + libvirt VM ubuntu name    : "libvirt-ex-kubernetes-cluster-vm-ubuntu-fb7243d"
  + libvirt cloudinit name    : "libvirt-ex-kubernetes-cluster-cloudinit-90ae032"
  + libvirt network name      : "libvirt-ex-kubernetes-cluster-network-8e48e3b"
  + libvirt pool name         : "libvirt-ex-kubernetes-cluster-vm_pool-862b2b5"
  + libvirt volume 0 name     : "libvirt-ex-kubernetes-cluster-linux-0-8d26fb6"
  + libvirt volume 1 name     : "libvirt-ex-kubernetes-cluster-linux-1-a6bb107"
  + libvirt volume 2 name     : "libvirt-ex-kubernetes-cluster-linux-2-0580cd6"
  + libvirt volume ubuntu name: "libvirt-ex-kubernetes-cluster-linux-ubuntu-d23a2c8"

Resources:
    + 4 to create
    9 unchanged

Do you want to perform this update? yes
Updating (kubernetes-cluster):
     Type                     Name                                     Status                  Info
     pulumi:pulumi:Stack      libvirt-py-vm-kubernetes-cluster         **failed**              1 error
 +   ├─ libvirt:index:Domain  libvirt-ex-kubernetes-cluster-vm-1       **creating failed**     1 error
 +   ├─ libvirt:index:Domain  libvirt-ex-kubernetes-cluster-vm-0       **creating failed**     1 error
 +   ├─ libvirt:index:Domain  libvirt-ex-kubernetes-cluster-vm-ubuntu  **creating failed**     1 error
 +   └─ libvirt:index:Domain  libvirt-ex-kubernetes-cluster-vm-2       **creating failed**     1 error


Diagnostics:
  libvirt:index:Domain (libvirt-ex-kubernetes-cluster-vm-0):
    error: 1 error occurred:
    	* error creating libvirt domain: internal error: qemu unexpectedly closed the monitor: qemu-system-x86_64: -spice port=5903,addr=127.0.0.1,disable-ticketing=on,seamless-migration=on: spice support is disabled

  libvirt:index:Domain (libvirt-ex-kubernetes-cluster-vm-ubuntu):
    error: 1 error occurred:
    	* error creating libvirt domain: internal error: qemu unexpectedly closed the monitor: qemu-system-x86_64: -spice port=5902,addr=127.0.0.1,disable-ticketing=on,seamless-migration=on: spice support is disabled

  pulumi:pulumi:Stack (libvirt-py-vm-kubernetes-cluster):
    error: update failed

  libvirt:index:Domain (libvirt-ex-kubernetes-cluster-vm-1):
    error: 1 error occurred:
    	* error creating libvirt domain: internal error: process exited while connecting to monitor: qemu-system-x86_64: -spice port=5900,addr=127.0.0.1,disable-ticketing=on,seamless-migration=on: spice support is disabled

  libvirt:index:Domain (libvirt-ex-kubernetes-cluster-vm-2):
    error: 1 error occurred:
    	* error creating libvirt domain: internal error: qemu unexpectedly closed the monitor: qemu-system-x86_64: -spice port=5901,addr=127.0.0.1,disable-ticketing=on,seamless-migration=on: spice support is disabled

Resources:
    9 unchanged

Duration: 3s
```

**Success** (with `qemu-ui-spice-core`)
```bash
Checking for file conflicts: .......................................................................................................................................................................................................................................................[done]
(1/4) Installing: libspice-server1-0.15.0-150400.2.8.x86_64 ........................................................................................................................................................................................................................[done]
(2/4) Installing: qemu-ui-opengl-6.2.0-150400.37.14.2.x86_64 .......................................................................................................................................................................................................................[done]
(3/4) Installing: qemu-audio-spice-6.2.0-150400.37.14.2.x86_64 .....................................................................................................................................................................................................................[done]
(4/4) Installing: qemu-ui-spice-core-6.2.0-150400.37.14.2.x86_64 ...................................................................................................................................................................................................................[done]
hypervisor:~/manderson/sles-development-box/Development/pulumi # pulumi up
Previewing update (kubernetes-cluster):
     Type                     Name                                     Plan
     pulumi:pulumi:Stack      libvirt-py-vm-kubernetes-cluster
 +   ├─ libvirt:index:Domain  libvirt-ex-kubernetes-cluster-vm-0       create
 +   ├─ libvirt:index:Domain  libvirt-ex-kubernetes-cluster-vm-1       create
 +   ├─ libvirt:index:Domain  libvirt-ex-kubernetes-cluster-vm-ubuntu  create
 +   └─ libvirt:index:Domain  libvirt-ex-kubernetes-cluster-vm-2       create


Outputs:
  + libvirt VM 0 name         : "libvirt-ex-kubernetes-cluster-vm-0-4b22c69"
  + libvirt VM 1 name         : "libvirt-ex-kubernetes-cluster-vm-1-cac5a1a"
  + libvirt VM 2 name         : "libvirt-ex-kubernetes-cluster-vm-2-8a3955b"
  + libvirt VM ubuntu name    : "libvirt-ex-kubernetes-cluster-vm-ubuntu-3c2b946"
  + libvirt cloudinit name    : "libvirt-ex-kubernetes-cluster-cloudinit-90ae032"
  + libvirt network name      : "libvirt-ex-kubernetes-cluster-network-8e48e3b"
  + libvirt pool name         : "libvirt-ex-kubernetes-cluster-vm_pool-862b2b5"
  + libvirt volume 0 name     : "libvirt-ex-kubernetes-cluster-linux-0-8d26fb6"
  + libvirt volume 1 name     : "libvirt-ex-kubernetes-cluster-linux-1-a6bb107"
  + libvirt volume 2 name     : "libvirt-ex-kubernetes-cluster-linux-2-0580cd6"
  + libvirt volume ubuntu name: "libvirt-ex-kubernetes-cluster-linux-ubuntu-d23a2c8"

Resources:
    + 4 to create
    9 unchanged

Do you want to perform this update? yes
Updating (kubernetes-cluster):
     Type                     Name                                     Status
     pulumi:pulumi:Stack      libvirt-py-vm-kubernetes-cluster
 +   ├─ libvirt:index:Domain  libvirt-ex-kubernetes-cluster-vm-0       created (39s)
 +   ├─ libvirt:index:Domain  libvirt-ex-kubernetes-cluster-vm-2       created (37s)
 +   ├─ libvirt:index:Domain  libvirt-ex-kubernetes-cluster-vm-ubuntu  created (38s)
 +   └─ libvirt:index:Domain  libvirt-ex-kubernetes-cluster-vm-1       created (38s)


Outputs:
  + libvirt VM 0 name         : "libvirt-ex-kubernetes-cluster-vm-0-b219654"
  + libvirt VM 1 name         : "libvirt-ex-kubernetes-cluster-vm-1-4796c37"
  + libvirt VM 2 name         : "libvirt-ex-kubernetes-cluster-vm-2-98ce3cd"
  + libvirt VM ubuntu name    : "libvirt-ex-kubernetes-cluster-vm-ubuntu-952de86"
  + libvirt cloudinit name    : "libvirt-ex-kubernetes-cluster-cloudinit-90ae032"
  + libvirt network name      : "libvirt-ex-kubernetes-cluster-network-8e48e3b"
  + libvirt pool name         : "libvirt-ex-kubernetes-cluster-vm_pool-862b2b5"
  + libvirt volume 0 name     : "libvirt-ex-kubernetes-cluster-linux-0-8d26fb6"
  + libvirt volume 1 name     : "libvirt-ex-kubernetes-cluster-linux-1-a6bb107"
  + libvirt volume 2 name     : "libvirt-ex-kubernetes-cluster-linux-2-0580cd6"
  + libvirt volume ubuntu name: "libvirt-ex-kubernetes-cluster-linux-ubuntu-d23a2c8"

Resources:
    + 4 created
    9 unchanged

Duration: 41s
```