### PR TITLE
MTL-2171 CI Fixes

### DIFF
--- a/roles/node_images_pre_install_toolkit/vars/packages/suse.yml
+++ b/roles/node_images_pre_install_toolkit/vars/packages/suse.yml
@@ -31,9 +31,9 @@ packages:
   - canu=1.7.1-2
   - cray-site-init=1.31.3-1
   - ilorest=4.2.0.0-20
-  - metal-basecamp=1.2.5-1
-  - metal-ipxe=2.4.3-1
+  - metal-basecamp=1.2.6-1
+  - metal-ipxe=2.4.4-1
   - pit-init=1.3.1-1
-  - pit-nexus=1.2.1-1
-  - pit-observability=1.0.6-1
+  - pit-nexus=1.2.2-1
+  - pit-observability=1.0.7-1
 patterns:


### PR DESCRIPTION
These four packages have new versions from some CI fixes.

`metal-basecamp` also includes some updated dependencies.
