### PR TITLE
MTL-2032 Fix pit and package URLs

### DIFF
--- a/roles/node_images_pre_install_toolkit/files/apache2/nexus.conf
+++ b/roles/node_images_pre_install_toolkit/files/apache2/nexus.conf
@@ -1,10 +1,28 @@
-<VirtualHost packages:80>
+# Necessary for the IP, pit, and pit.nmn to not be proxied.
+<VirtualHost *:80>
+  ServerName pit.nmn
+</VirtualHost>
+
+# Necessary for packages to proxy to nexus.
+<VirtualHost *:80>
   ProxyPreserveHost On
   ProxyRequests Off
   AllowEncodedSlashes NoDecode
   ProxyTimeout 300
   ServerName packages
   ServerAlias packages
+  ProxyPass / http://localhost:8081/ nocanon
+  ProxyPassReverse / http://localhost:8081/
+</VirtualHost>
+
+# Necessary for packages.nmn to proxy to nexus.
+<VirtualHost *:80>
+  ProxyPreserveHost On
+  ProxyRequests Off
+  AllowEncodedSlashes NoDecode
+  ProxyTimeout 300
+  ServerName packages.nmn
+  ServerAlias packages.nmn
   ProxyPass / http://localhost:8081/ nocanon
   ProxyPassReverse / http://localhost:8081/
 </VirtualHost>


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes:
- Requires:
- Relates to:

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->
Everything is resolving to nexus.

This fixes non nexus URLs so they are not proxied.

Tested with the following cases

Before (broken):
```
10.252.1.4         - nexus
pit                - nexus
pit.nmn            - nexus
packages           - nexus
packages.nmn       - nexus
```

Now (fixed):
```
10.252.1.4         - pit
pit                - pit
pit.nmn.           - pit
packages.          - nexus
packages.nmn       - nexus
```

It is unclear when this broke, because 1.5 deployments have been running with a `nexus.conf` installed.

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I have tested this by building an image using this branch HEAD, or this is does not pertain to the node-images pipeline.
- [x] I tested this on internal system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
- [x] I tested this on a vshasta system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
