### PR TITLE
CASMCMS-8599: Add CLI support for BOS v2 session include_disabled option

### DIFF
--- a/roles/node_images_base/vars/packages/suse.yml
+++ b/roles/node_images_base/vars/packages/suse.yml
@@ -49,7 +49,7 @@ packages:
   - google-guest-configs=20220211.00-150400.13.3.1
   - google-guest-oslogin=20220721.00-150000.1.30.1
   # csm
-  - craycli=0.82.4-1
+  - craycli=0.82.5-1
   - csm-auth-utils=1.0.0-1
   - csm-node-identity=1.0.20-1
   - csm-node-heartbeat=2.0-3


### PR DESCRIPTION
https://github.com/Cray-HPE/csm/pull/2486