### PR TITLE
CASM-4366: Upgrade pit-observability images (Grafana and prometheus) to the latest version

### DIFF
--- a/roles/node_images_pre_install_toolkit/vars/packages/suse.yml
+++ b/roles/node_images_pre_install_toolkit/vars/packages/suse.yml
@@ -35,5 +35,5 @@ packages:
   - metal-ipxe=2.4.4-1
   - pit-init=1.3.1-1
   - pit-nexus=1.2.2-1
-  - pit-observability=1.0.7-1
+  - pit-observability=1.0.8-1
 patterns:


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: CASM-4366

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request
- Docs Pull Request
- RFE Pull Request

<!--- words; describe what this change is and what it is for. -->

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [x] I have included documentation in my PR (or it is not required)
- [x] I have tested this by building an image using this branch HEAD, or this is does not pertain to the node-images pipeline.
- [x] I tested this on internal system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
- [x] I tested this on a vshasta system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
