### PR TITLE
Remove required tenant prompt when initializing (CASMPET-6649)

### DIFF
--- a/roles/node_images_base/vars/packages/suse.yml
+++ b/roles/node_images_base/vars/packages/suse.yml
@@ -49,7 +49,7 @@ packages:
   - google-guest-configs=20220211.00-150400.13.3.1
   - google-guest-oslogin=20220721.00-150000.1.30.1
   # csm
-  - craycli=0.82.5-1
+  - craycli=0.82.6-1
   - csm-auth-utils=1.0.0-1
   - csm-node-identity=1.0.20-1
   - csm-node-heartbeat=2.0-3


### PR DESCRIPTION
### Summary and Scope

Change --tenant argument to be optional to prevent BW incompatible change for non-interactive use cases.

### Issues and Related PRs

* https://jira-pro.it.hpe.com:8443/browse/CASMPET-6649

### Testing

Tested on ashton:

```
ncn-m003:~/.config/cray/configurations # cray init --hostname https://api-gw-service-nmn.local
Overwrite configuration file at: /root/.config/cray/configurations/default ? [y/N]: y
Username: vshasta
Password:
Success!

Initialization complete.
ncn-m003:~/.config/cray/configurations # cat default
[core]
hostname = "https://api-gw-service-nmn.local"
tenant = ""

[auth.login]
username = "vshasta"
```

```
ncn-m003:~/.config/cray/configurations # cray init --hostname https://api-gw-service-nmn.local --tenant vcluster-blue
Overwrite configuration file at: /root/.config/cray/configurations/default ? [y/N]: y
Username: vshasta
Password:
Success!

Initialization complete.

ncn-m003:~/.config/cray/configurations # cat default
[core]
hostname = "https://api-gw-service-nmn.local"
tenant = "vcluster-blue"

[auth.login]
username = "vshasta"
```

Was a fresh Install tested? N
Was an Upgrade tested?      N - N/A
Was a Downgrade tested?     N - N/A
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

### Risks and Mitigations

Low

### Requires:

* Nothing
