### PR TITLE
MTL-2032 Fix group repo names

### DIFF
--- a/scripts/nexus/setup-nexus.sh
+++ b/scripts/nexus/setup-nexus.sh
@@ -435,12 +435,12 @@ function nexus-create-repo-group() {
     "${NEXUS_URL}/service/rest/v1/repositories" \
     -s \
     --header "Content-type: application/json" \
-    | jq '.[] | select(.name=="'"${repo_name}"'")')"
+    | jq '.[] | select(.name=="'"${repo_group_name}"'")')"
     if [ -z "$exists" ]; then
-        echo -n "Creating repo group '$repo_name' with: $repo_names ... "
+        echo -n "Creating repo group '$repo_group_name' with: $repo_names ... "
         method=POST
     else
-        echo -n "Updating existing repo group '$repo_name' with: $repo_names ... "
+        echo -n "Updating existing repo group '$repo_group_name' with: $repo_names ... "
         uri="$uri/$repo_group_name"
         method=PUT
     fi


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->


#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->
The `exists` variable was checking the member name instead of the group repo name, this was leading the code to believe the repo group already existed and it was doing a `PATCH` which doesn't work.

This fixes the code to properly use `repo_group_name where necessary, and successfully creates the repo group.

```bash
# bad
Updating existing repo 'csm-1.5.0-beta.15-noos' ... Done
Updating existing repo group 'csm-1.5.0-beta.15-noos' with: csm-1.5.0-beta.15-noos ... Done
Uploading /var/www/ephemeral/csm-1.5.0-beta.15/rpm/cray/csm/noos to csm-1.5.0-beta.15-noos ..
```

``bash
# good
Updating existing repo 'csm-1.5.0-beta.15-noos' ... Done
Creating repo group 'csm-noos' with: csm-1.5.0-beta.15-noos ... Done
Uploading /var/www/ephemeral/csm-1.5.0-beta.15/rpm/cray/csm/noos to csm-1.5.0-beta.15-noos ... Done
```

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I have tested this by building an image using this branch HEAD, or this is does not pertain to the node-images pipeline.
- [x] I tested this on internal system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
- [ ] I tested this on a vshasta system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
