### PR TITLE
MTL-2159 backport lts/csm-1.5

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -25,3 +25,6 @@
 force_color             = True
 interpreter_python      = auto_silent
 log_path                = /var/log/cray/ansible.log
+bin_ansible_callbacks   = True
+stdout_callback         = yaml
+verbosity               = 1

--- a/roles/node_images_base/vars/packages/suse.yml
+++ b/roles/node_images_base/vars/packages/suse.yml
@@ -58,7 +58,7 @@ packages:
   - at=3.2.2-150400.4.3.10
   - bash-completion=2.7-150400.13.3.1
   - bc=1.07.1-11.37
-  - bind-utils=9.16.38-150400.5.20.2
+  - bind-utils=9.16.42-150400.5.27.1
   - bsdtar=3.5.1-150400.3.12.1
   - ca-certificates-mozilla=2.60-150200.27.1
   - ca-certificates=2+git20210309.21162a6-2.1
@@ -81,9 +81,9 @@ packages:
   - git-core=2.35.3-150300.10.27.1
   - gnuplot=5.4.3-150400.1.6
   - hdparm=9.62-150400.1.7
-  - helm-bash-completion=3.9.4-150000.1.10.3
-  - helm-zsh-completion=3.9.4-150000.1.10.3
-  - helm=3.9.4-150000.1.10.3
+  - helm=3.11.2-150000.1.21.1
+  - helm-bash-completion=3.11.2-150000.1.21.1
+  - helm-zsh-completion=3.11.2-150000.1.21.1
   - hpe-yq=4.33.3-1
   - htop=3.0.5-bp154.1.30
   - hwloc=2.5.0-150400.1.9
@@ -101,7 +101,7 @@ packages:
   - libfreebl3-hmac=3.79.4-150400.3.29.1
   - libfreebl3=3.79.4-150400.3.29.1
   - liblldp_clif1=1.1+44.0f781b4162d3-3.3.1
-  - libopenssl1_1=1.1.1l-150400.7.34.1
+  - libopenssl1_1=1.1.1l-150400.7.42.1
   - libpwquality1=1.4.4-150400.15.4
   - libstoragemgmt=1.8.5-3.3.1
   - libsystemd0=249.16-150400.8.25.7
@@ -114,11 +114,11 @@ packages:
   - open-lldp=1.1+44.0f781b4162d3-3.3.1
   - openscap-utils=1.3.6-150400.11.3.1
   - openscap=1.3.6-150400.11.3.1
-  - openssh-clients=8.4p1-150300.3.15.4
-  - openssh-common=8.4p1-150300.3.15.4
-  - openssh-server=8.4p1-150300.3.15.4
-  - openssh=8.4p1-150300.3.15.4
-  - openssl-1_1=1.1.1l-150400.7.34.1
+  - openssh-clients=8.4p1-150300.3.18.2
+  - openssh-common=8.4p1-150300.3.18.2
+  - openssh-server=8.4p1-150300.3.18.2
+  - openssh=8.4p1-150300.3.18.2
+  - openssl-1_1=1.1.1l-150400.7.42.1
   - perf=5.14.21-150400.44.13.1
   - perl-File-BaseDir=0.09-bp154.1.25
   - perl-File-Which=1.22-1.22
@@ -143,8 +143,8 @@ packages:
   - unixODBC=2.3.9-150400.14.5
   - unzip=6.00-150000.4.11.1
   - usbutils=014-3.3.1
-  - vim-data=9.0.1443-150000.5.40.1
-  - vim=9.0.1443-150000.5.40.1
+  - vim-data=9.0.1443-150000.5.43.1
+  - vim=9.0.1443-150000.5.43.1
   - which=2.21-2.20
   - yq-bash-completion=4.18.1-bp154.1.17
   - yq-zsh-completion=4.18.1-bp154.1.17
@@ -153,7 +153,7 @@ packages:
   - python3-Jinja2=2.10.1-3.10.2
   - python3-MarkupSafe=1.0-1.29
   - python3-PyYAML=5.4.1-1.1
-  - python3-boto3=1.23.4-150200.23.9.1
+  - python3-boto3=1.26.89-150200.23.12.1
   - python3-click=7.0-1.27
   - python3-colorama=0.4.4-5.4.1
   - python3-defusedxml=0.6.0-1.42

--- a/roles/node_images_ncn_common/vars/packages/suse.yml
+++ b/roles/node_images_ncn_common/vars/packages/suse.yml
@@ -25,7 +25,7 @@
 packages:
   - amsd=3.3.0-1773.7.sles15
   - apparmor-profiles=3.0.4-150400.5.3.1
-  - aws-cli=1.24.4-150200.30.8.1
+  - aws-cli=1.27.89-150200.30.11.1
   - ceph-common<17.2.6
   - conman=0.3.0-150400.9.10
   - cpupower=5.14-150400.3.3.1
@@ -37,15 +37,15 @@ packages:
   - hplip=3.21.10-150400.3.5.1
   - ipmitool=1.8.19.gb7c0d66-0
   - ipset=7.15-150400.12.3.2
-  - java-1_8_0-ibm-plugin=1.8.0_sr8.0-150000.3.71.1
-  - java-1_8_0-ibm=1.8.0_sr8.0-150000.3.71.1
+  - java-1_8_0-ibm-plugin=1.8.0_sr8.5-150000.3.74.1
+  - java-1_8_0-ibm=1.8.0_sr8.5-150000.3.74.1
   - jq=1.6-3.3.1
   - keepalived=2.0.19-bp152.1.9
   - kubectl=1.21.12-0
   - lsof=4.91-1.11
   - ltrace=0.7.91-4.3
-  - mariadb-tools=10.6.12-150400.3.20.5
-  - mariadb=10.6.12-150400.3.20.5
+  - mariadb-tools=10.6.13-150400.3.23.1
+  - mariadb=10.6.13-150400.3.23.1
   - mdadm=4.1-150300.24.24.2
   - minicom=2.7.1-1.19
   - mlocate=0.26-150400.16.3.1
@@ -66,7 +66,7 @@ packages:
   - sysstat=12.0.2-3.33.1
   - systemtap=4.6-150400.1.7
   - wget=1.20.3-150000.3.15.1
-  - wireshark=3.6.13-150000.3.89.1
+  - wireshark=3.6.14-150000.3.92.1
   - xfsdump=3.1.6-1.30
   # CMS Team
   - cfs-debugger=1.4.0-1
@@ -82,7 +82,7 @@ packages:
   - goss-servers=1.16.32-1
   - hpe-csm-goss-package=0.3.21-hpe3
   - hpe-csm-scripts=0.5.5-1
-  - loftsman=1.2.0-2
+  - loftsman=1.2.0-3
   - manifestgen=1.3.9-1
   # CM cli
   - cm-cli=1.5.0-1

--- a/roles/node_images_storage_ceph/vars/packages/suse.yml
+++ b/roles/node_images_storage_ceph/vars/packages/suse.yml
@@ -24,7 +24,7 @@
 ---
 packages:
   - cephadm<17.2.6
-  - golang-github-prometheus-node_exporter=1.3.0-150100.3.20.2
+  - golang-github-prometheus-node_exporter=1.5.0-150100.3.23.2
   - libfmt8=8.0.1-150400.1.8
   - ses-release=7-64.1
 patterns:


### PR DESCRIPTION
### Summary and Scope

Backport of #234 
Changes:
- CVE updates
- Move ansible stdout_callback into ansible.cfg

- Fixes: https://jira-pro.it.hpe.com:8443/browse/MTL-2159 
- Relates to: https://jira-pro.it.hpe.com:8443/browse/MTL-2188

CVE's addressed:
- SUSE-SU-2023:2667-1
- SUSE-SU-2023:2179-1
- SUSE-SU-2023:0310-1
- SUSE-SU-2022:0805-1
- SUSE-SU-2021:2817-1
- SUSE-SU-2023:0375-1
- SUSE-SU-2023:0631-1
- SUSE-SU-2023:0343-1
- SUSE-SU-2022:3745-1

#### Issue Type

- RFE Pull Request

### Prerequisites

- [x] I have included documentation in my PR (or it is not required)
- [x] I have tested this by building an image using this branch HEAD, or this is does not pertain to the node-images pipeline.
- [x] I tested this on internal system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
- [x] I tested this on a vshasta system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
