### PR TITLE
CASMPET-6650-csm-1.5

### DIFF
--- a/roles/node_images_storage_ceph/vars/packages/suse.yml
+++ b/roles/node_images_storage_ceph/vars/packages/suse.yml
@@ -23,7 +23,7 @@
 #
 ---
 packages:
-  - cephadm<17.2.6
+  - cephadm<17.2.7
   - golang-github-prometheus-node_exporter=1.5.0-150100.3.23.2
   - libfmt8=8.0.1-150400.1.8
   - ses-release=7-64.1


### PR DESCRIPTION
### Summary and Scope

Upload docker images in tarball to pit-nexus. This is done already before CSM services are deployed. This is just moving this step earlier in the process so that storage nodes can use the container images in pit nexus when the storage nodes boot.

Relates to: [CASMPET-6650](https://jira-pro.it.hpe.com:8443/browse/CASMPET-6650)

