### PR TITLE
MTL-2189 Break out packages; mitigate CVEs in hypervisor

### DIFF
--- a/pb_node_images_application.yml
+++ b/pb_node_images_application.yml
@@ -29,4 +29,6 @@
     HTTPS_PROXY: "{{ HTTPS_PROXY }}"
   roles:
     - node_images_base
+    - packages_csm
+    - packages_user
     - node_images_application

--- a/pb_node_images_compute.yml
+++ b/pb_node_images_compute.yml
@@ -29,4 +29,6 @@
     HTTPS_PROXY: "{{ HTTPS_PROXY }}"
   roles:
     - node_images_base
+    - packages_csm
+    - packages_user
     - node_images_compute

--- a/pb_node_images_kubernetes.yml
+++ b/pb_node_images_kubernetes.yml
@@ -27,4 +27,6 @@
   become: true # Enable builds that do not login as root to escalate privilege.
   roles:
     - node_images_base
+    - packages_csm
+    - packages_user
     - node_images_kubernetes

--- a/pb_node_images_management.yml
+++ b/pb_node_images_management.yml
@@ -27,4 +27,6 @@
   become: true # Enable builds that do not login as root to escalate privilege.
   roles:
     - node_images_base
+    - packages_csm
+    - packages_user
     - node_images_management

--- a/pb_node_images_ncn-common.yml
+++ b/pb_node_images_ncn-common.yml
@@ -27,4 +27,6 @@
   become: true # Enable builds that do not login as root to escalate privilege.
   roles:
     - node_images_base
+    - packages_csm
+    - packages_user
     - node_images_ncn_common

--- a/roles/node_images_base/vars/packages/suse-aarch64.yml
+++ b/roles/node_images_base/vars/packages/suse-aarch64.yml
@@ -23,8 +23,10 @@
 #
 ---
 packages:
-  # Boot packages
+  # rationale: A dependency of SLES's GRUB package.
   - grub2-branding-SLE=15-150400.38.3.1
+  # rationale: A dependency needed for the x86_64 EFI GRUB boot loader.
   - grub2-arm64-efi=2.06-150400.11.30.1
+  # rationale: Provides a boot loader for booting into Linux.
   - grub2=2.06-150400.11.30.1
 patterns:

--- a/roles/node_images_base/vars/packages/suse.yml
+++ b/roles/node_images_base/vars/packages/suse.yml
@@ -23,151 +23,118 @@
 #
 ---
 packages:
-  # NTP
+  #
+  ## OS Packages
+  #
+  # rationale: Necessary for network time protocol (NTP).
   - chrony=4.1-150400.19.4
-  - cron=4.2-150400.84.3.1
-  # Partitioning / bootloader /dracut
-  - checkmedia=6.1-150400.1.5
-  - cryptsetup=2.4.3-150400.1.110
-  - dosfstools=4.1-3.6.1
+  # rationale: Necessary for viewing and managing routing tables.
   - iproute2=5.14-150400.1.8
-  - less=590-150400.3.3.1
-  - lvm2=2.03.05-150400.185.1
-  - mdadm=4.1-150300.24.24.2
-  - mtools=4.0.35-150400.1.11
-  - nvme-cli=2.0+30.g86f82c58cb97-150400.3.15.1
-  - pciutils=3.5.6-150300.13.3.1
-  - squashfs=4.4-1.1
-  - tpm2.0-abrmd=2.4.0-150400.1.6
-  - tpm2.0-tools=5.2-150400.4.6
-  - xfsprogs=5.13.0-150400.3.3.1
-  - xorriso=1.4.6-1.29
-  # kdump analysis
-  - crash=7.3.0-150400.3.5.8
-  # Google Compute
-  - google-guest-agent=20230221.00-150000.1.34.1
-  - google-guest-configs=20220211.00-150400.13.3.1
-  - google-guest-oslogin=20220721.00-150000.1.30.1
-  # csm
-  - craycli=0.82.6-1
-  - csm-auth-utils=1.0.0-1
-  - csm-node-identity=1.0.20-1
-  - csm-node-heartbeat=2.0-3
-  - spire-agent=1.5.5-1.7
-  # user tools
-  - at=3.2.2-150400.4.3.10
-  - bash-completion=2.7-150400.13.3.1
-  - bc=1.07.1-11.37
-  - bind-utils=9.16.42-150400.5.27.1
-  - bsdtar=3.5.1-150400.3.12.1
-  - ca-certificates-mozilla=2.60-150200.27.1
-  - ca-certificates=2+git20210309.21162a6-2.1
-  - curl=8.0.1-150400.5.23.1
-  - dkms=2.6.1-bp154.1.30
-  - dmidecode=3.4-150400.16.8.1
-  - dump=0.4b47-150400.1.10
-  - ebtables=2.0.11-1.1
-  - elfutils-lang=0.185-150400.5.3.1
-  - elfutils=0.185-150400.5.3.1
-  - emacs=27.2-150400.3.6.1
-  - ethtool=5.14-150400.1.6
-  - expect=5.45.4-3.3.1
-  - fontconfig=2.13.1-150400.1.4
-  - fonts-config=20200609+git0.42e2b1b-4.7.1
-  - fping=4.0-4.3.2
-  - fuse=2.9.7-3.3.1
-  - gdb=12.1-150400.15.6.1
-  - genders=1.27.3-150400.8.7
-  - git-core=2.35.3-150300.10.27.1
-  - gnuplot=5.4.3-150400.1.6
-  - hdparm=9.62-150400.1.7
-  - helm=3.11.2-150000.1.21.1
-  - helm-bash-completion=3.11.2-150000.1.21.1
-  - helm-zsh-completion=3.11.2-150000.1.21.1
-  - hpe-yq=4.33.3-1
-  - htop=3.0.5-bp154.1.30
-  - hwloc=2.5.0-150400.1.9
-  - iproute2-bash-completion=5.14-150400.1.8
-  - iputils=20211215-150400.3.3.2
-  - issue-generator=1.7-1.17
-  - kmod-bash-completion=29-4.15.1
-  - ledmon=0.94-150400.5.5
-  - libasm1=0.185-150400.5.3.1
-  - libbd_mdraid2=2.26-150400.1.5
-  - libcanberra-gtk0=0.30-150400.13.10
-  - libdw1=0.185-150400.5.3.1
-  - libelf-devel=0.185-150400.5.3.1
-  - libelf1=0.185-150400.5.3.1
-  - libfreebl3-hmac=3.79.4-150400.3.29.1
-  - libfreebl3=3.79.4-150400.3.29.1
-  - liblldp_clif1=1.1+44.0f781b4162d3-3.3.1
-  - libopenssl1_1=1.1.1l-150400.7.42.1
-  - libpwquality1=1.4.4-150400.15.4
-  - libstoragemgmt=1.8.5-3.3.1
+  # rationale: Dependency for daemon necessities.
   - libsystemd0=249.16-150400.8.25.7
+  # rationale: Dependency for daemon necessities.
   - libudev1=249.16-150400.8.25.7
-  - libunwind-devel=1.5.0-4.5.1
-  - lsscsi=0.28-1.24
-  - man=2.7.6-6.22
-  - nvme-cli-bash-completion=2.0+30.g86f82c58cb97-150400.3.15.1
-  - nvme-cli-zsh-completion=2.0+30.g86f82c58cb97-150400.3.15.1
-  - open-lldp=1.1+44.0f781b4162d3-3.3.1
-  - openscap-utils=1.3.6-150400.11.3.1
-  - openscap=1.3.6-150400.11.3.1
-  - openssh-clients=8.4p1-150300.3.18.2
-  - openssh-common=8.4p1-150300.3.18.2
-  - openssh-server=8.4p1-150300.3.18.2
-  - openssh=8.4p1-150300.3.18.2
-  - openssl-1_1=1.1.1l-150400.7.42.1
-  - perf=5.14.21-150400.44.13.1
-  - perl-File-BaseDir=0.09-bp154.1.25
-  - perl-File-Which=1.22-1.22
-  - perl-MailTools=2.19-1.20
-  - perl-doc=5.26.1-150300.17.11.1
-  - pixz=1.0.6-1.13
-  - postfix=3.5.9-5.9.2
-  - rsync=3.2.3-150400.3.8.1
-  - rsyslog=8.2106.0-150400.5.11.1
-  - screen=4.6.2-5.3.1
-  - strace=5.14-150400.1.7
-  - sudo=1.9.9-150400.4.26.1
+  # rationale: Dependency for daemon necessities.
   - systemd-coredump=249.16-150400.8.25.7
+  # rationale: Dependency for daemon necessities.
   - systemd-lang=249.16-150400.8.25.7
+  # rationale: Necessary for daemons.
   - systemd-sysvinit=249.16-150400.8.25.7
+  # rationale: Necessary for daemons.
   - systemd=249.16-150400.8.25.7
-  - tar=1.34-150000.3.31.1
-  - tcpdump=4.99.1-150400.1.8
-  - tmux=3.1c-bp152.2.3.1
-  - traceroute=2.0.21-1.29
+  # rationale: Necessary for TPM2.
+  - tpm2.0-abrmd=2.4.0-150400.1.6
+  # rationale: Necessary for TPM2.
+  - tpm2.0-tools=5.2-150400.4.6
+  # rationale: Necessary for hardware interfaces.
   - udev=249.16-150400.8.25.7
-  - unixODBC=2.3.9-150400.14.5
-  - unzip=6.00-150000.4.11.1
+  #
+  ## Filesystems and block device helpers
+  #
+  # rationale: Necessary for validating media before destructive operations.
+  - checkmedia=6.1-150400.1.5
+  # rationale: Necessary for Linux unified key setup devices (LUKS).
+  - cryptsetup=2.4.3-150400.1.110
+  # rationale: Necessary for file allocation table file systems (FAT/FAT32/vfat).
+  - dosfstools=4.1-3.6.1
+  # rationale: Necessary for Linux volume managment (LVM)
+  - lvm2=2.03.05-150400.185.1
+  # rationale: Necessary for Intel servers for properly controling storage activity LEDs when MD RAID is in use.
+  - ledmon=0.94-150400.5.5
+  # rationale: Necessary for multiple device (MD) software RAID.
+  - mdadm=4.1-150300.24.24.2
+  # rationale: Necessary for constructing boot loader images.
+  - mtools=4.0.35-150400.1.11
+  # rationale: Necessary for NVME control in a failed initramFS (required by dracut).
+  - nvme-cli=2.0+30.g86f82c58cb97-150400.3.15.1
+  # rationale: Necessary for manipulating squash file systems.
+  - squashfs=4.4-1.1
+  # rationale: Necessary for extended file system (XFS) support.
+  - xfsprogs=5.13.0-150400.3.3.1
+  # rationale: Necessary for creating ISO disk images.
+  - xorriso=1.4.6-1.29
+  #
+  ## Google Cloud
+  #
+  # rationale: Enables GCE platform features.
+  - google-guest-agent=20230221.00-150000.1.34.1
+  # rationale: Support for GCE guest environment and functionality.
+  - google-guest-configs=20220211.00-150400.13.3.1
+  # rationale: Google account authentication.
+  - google-guest-oslogin=20220721.00-150000.1.30.1
+  #
+  ## Kernel Helpers
+  #
+  # rationale: Necessary for analyzing a kernel crash dump.
+  - crash=7.3.0-150400.3.5.8
+  # rationale: Necessary for the dynamic kernel module support.
+  - dkms=2.6.1-bp154.1.30
+  #
+  ## Admin experience / sanity
+  #
+  # rationale: Desired for easy navigation through bourne again shell (BASH).
+  - bash-completion=2.7-150400.13.3.1
+  # rationale: Desired for easy viewing of kernel modules.
+  - kmod-bash-completion=29-4.15.1
+  # rationale: Desired for easy viewing of files.
+  - less=590-150400.3.3.1
+  # rationale: Desired for easy navigation of NVME devices in bourne again shell (BASH).
+  - nvme-cli-bash-completion=2.0+30.g86f82c58cb97-150400.3.15.1
+  # rationale: Desired for easy navigation of NVME devices in Zshell.
+  - nvme-cli-zsh-completion=2.0+30.g86f82c58cb97-150400.3.15.1
+  # Analysis / Triage data Collection
+  # rationale: Desired for viewing and dumping Ethernet controller and port information.
+  - ethtool=5.14-150400.1.6
+  # rationale: Desired for easy usage of ip commands.
+  - iproute2-bash-completion=5.14-150400.1.8
+  # rationale: Desired for basic IPv4 and IPv6 probing (provides ping).
+  - iputils=20211215-150400.3.3.2
+  # rationale: Desired for viewing and dumping small computer system interface (SCSI) devices.
+  - lsscsi=0.28-1.24
+  # rationale: Necessary for viewing manuals.
+  - man=2.7.6-6.22
+  # rationale: Necessary for openscap.
+  - openscap-utils=1.3.6-150400.11.3.1
+  # rationale: Necessary for running CVE scans.
+  - openscap=1.3.6-150400.11.3.1
+  # rationale: Necessary for link layer discovery protocol (LLDP) during early startup.
+  - open-lldp=1.1+44.0f781b4162d3-3.3.1
+  # rationale: Necessary for incoming and outgoing secure shells.
+  - openssh=8.4p1-150300.3.18.2
+  # rationale: Necessary for viewing, dumping, and inspecting PCI devices.
+  - pciutils=3.5.6-150300.13.3.1
+  # rationale: Necessary for efficient file transfers.
+  - rsync=3.2.3-150400.3.8.1
+  # rationale: Necessary for inspecting stack traces for applications.
+  - strace=5.14-150400.1.7
+  # rationale: Necessary for changing users.
+  - sudo=1.9.9-150400.4.26.1
+  # rationale: Necessary for monitoring and triaging IP connections.
+  - tcpdump=4.99.1-150400.1.8
+  # rationale: Necessary for triaging and debugging packet routes.
+  - traceroute=2.0.21-1.29
+  # rationale: Necessary for viewing, dumping, and inspecting USB devices.
   - usbutils=014-3.3.1
-  - vim-data=9.0.1443-150000.5.43.1
-  - vim=9.0.1443-150000.5.43.1
+  # rationale: Necessary for resolving where an application is actually running from.
   - which=2.21-2.20
-  - yq-bash-completion=4.18.1-bp154.1.17
-  - yq-zsh-completion=4.18.1-bp154.1.17
-  - zip=3.0-2.22
-  # Python
-  - python3-Jinja2=2.10.1-3.10.2
-  - python3-MarkupSafe=1.0-1.29
-  - python3-PyYAML=5.4.1-1.1
-  - python3-boto3=1.26.89-150200.23.12.1
-  - python3-click=7.0-1.27
-  - python3-colorama=0.4.4-5.4.1
-  - python3-defusedxml=0.6.0-1.42
-  - python3-dmidecode=3.12.2-150400.14.3.1
-  - python3-gobject=3.42.2-150400.3.3.2
-  - python3-ipaddr=2.1.11-2.24
-  - python3-kubernetes=8.0.1-150100.3.7.1
-  - python3-lxml=4.7.1-150200.3.10.1
-  - python3-netaddr=0.7.19-1.17
-  - python3-pexpect=4.8.0-150400.13.6
-  - python3-pyroute2=0.5.10-3.3.1
-  - python3-requests-oauthlib=0.8.0-3.4.1
-  - python3-requests=2.24.0-6.10.2
-  - python3-rpm=4.14.3-150300.55.1
-  - python3-six=1.14.0-12.1
-  - python3-urllib3=1.25.10-9.14.1
 patterns:

--- a/roles/node_images_hypervisor/vars/packages/suse.yml
+++ b/roles/node_images_hypervisor/vars/packages/suse.yml
@@ -34,17 +34,13 @@ packages:
   # rationale: Free range routing.
   - frr=8.4-lp154.50.1
   # rationale: Necessary for Mercury software proof-of-concepts.
-  - gcc-c++=7-3.9.1
-  # rationale: Necessary for Mercury software proof-of-concepts.
-  - libstdc++-devel=7-3.9.1
-  # rationale: Necessary for Mercury software proof-of-concepts.
   - libguestfs0=1.44.2-150400.3.3.1
   # rationale: Dependency of libvirt.
-  - libvirt-client=8.0.0-150400.7.3.1
+  - libvirt-client=8.0.0-150400.7.6.1
   # rationale: Dependency of libvirt.
-  - libvirt-devel=8.0.0-150400.7.3.1
+  - libvirt-devel=8.0.0-150400.7.6.1
   # rationale: Hypervisor virtualization API.
-  - libvirt=8.0.0-150400.7.3.1
+  - libvirt=8.0.0-150400.7.6.1
   # rationale: Necessary for Mercury software proof-of-concepts.
   - libxslt-tools=1.1.34-150400.3.3.1
   # rationale: Proof-of-concept item for launching virtual machines.

--- a/roles/node_images_hypervisor/vars/packages/suse.yml
+++ b/roles/node_images_hypervisor/vars/packages/suse.yml
@@ -23,30 +23,42 @@
 #
 ---
 packages:
-  # cloud-init often updates and goes missing in repodata, use `<23.2` to grab 23.1 no matter the release.
+  # rationale: Application for faciliatting configuring a hypervisor node.
+  - crucible=0.0.1-1
+  # rationale: SUSE's cloud-init config packages.
   - cloud-init-config-suse<23.2
+  # rationale: Documentation for cloud-init
   - cloud-init-doc<23.2
+  # rationale: Automates server provisioning.
   - cloud-init<23.2
+  # rationale: Free range routing.
   - frr=8.4-lp154.50.1
-  - helm=3.11.2-150000.1.21.1
-  - helm-bash-completion=3.11.2-150000.1.21.1
-  - helm-zsh-completion=3.11.2-150000.1.21.1
+  # rationale: Necessary for Mercury software proof-of-concepts.
   - gcc-c++=7-3.9.1
+  # rationale: Necessary for Mercury software proof-of-concepts.
   - libstdc++-devel=7-3.9.1
-  - ruby2.5-devel=2.5.9-150000.4.26.1
-  - ruby3.1-devel=3.1.4-lp154.36.1
+  # rationale: Necessary for Mercury software proof-of-concepts.
   - libguestfs0=1.44.2-150400.3.3.1
+  # rationale: Dependency of libvirt.
   - libvirt-client=8.0.0-150400.7.3.1
+  # rationale: Dependency of libvirt.
   - libvirt-devel=8.0.0-150400.7.3.1
+  # rationale: Hypervisor virtualization API.
   - libvirt=8.0.0-150400.7.3.1
+  # rationale: Necessary for Mercury software proof-of-concepts.
   - libxslt-tools=1.1.34-150400.3.3.1
-  - mkisofs=3.02~a09-4.6.1
-  - nfs-kernel-server=2.1.1-150100.10.32.1
+  # rationale: Proof-of-concept item for launching virtual machines.
   - pulumi-3.73.0-2
+  # rationale: Drivers for VMs.
   - qemu-kvm=6.2.0-150400.37.14.2
+  # rationale: Necessary for providing consoles to VMs.
   - qemu-ui-spice-core=6.2.0-150400.37.14.2
-  - supportutils-plugin-cloud-init=1.1-150400.1.5
+  # rationale: Proof-of-concept item for orchestrating virtual machines.
   - terraform=0.13.4-6.3.1
+  # rationale: Proof-of-concept item for launching virtual machines.
+  - virt-install-4.0.0-150400.3.3.1.noarch
 patterns:
+  # rationale: SUSE KVM dependencies.
   - patterns-server-kvm_server=20180302-11.1
+  # rationale: SUSE KVM tools.
   - patterns-server-kvm_tools=20180302-11.1

--- a/roles/node_images_hypervisor/vars/packages/suse.yml
+++ b/roles/node_images_hypervisor/vars/packages/suse.yml
@@ -43,14 +43,10 @@ packages:
   - libvirt=8.0.0-150400.7.6.1
   # rationale: Necessary for Mercury software proof-of-concepts.
   - libxslt-tools=1.1.34-150400.3.3.1
-  # rationale: Proof-of-concept item for launching virtual machines.
-  - pulumi-3.73.0-2
   # rationale: Drivers for VMs.
   - qemu-kvm=6.2.0-150400.37.14.2
   # rationale: Necessary for providing consoles to VMs.
   - qemu-ui-spice-core=6.2.0-150400.37.14.2
-  # rationale: Proof-of-concept item for orchestrating virtual machines.
-  - terraform=0.13.4-6.3.1
   # rationale: Proof-of-concept item for launching virtual machines.
   - virt-install-4.0.0-150400.3.3.1.noarch
 patterns:

--- a/roles/packages_csm/tasks/main.yml
+++ b/roles/packages_csm/tasks/main.yml
@@ -22,25 +22,11 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 ---
-packages:
-  # rationale: Necessary for standardized network interface device names.
-  - biosdevname=0.7.3-5.3.1
-  # rationale: A dependency of SLES's GRUB package.
-  - grub2-branding-SLE=15-150400.38.3.1
-  # rationale: Provides a boot loader for booting into Linux.
-  - grub2=2.06-150400.11.30.1
-  # rationale: A dependency needed for the x86_64 EFI GRUB boot loader.
-  - grub2-i386-pc=2.06-150400.11.30.1
-  # rationale: Necessary for creating and managing an x86_64 EFI GRUB boot loader.
-  - grub2-x86_64-efi=2.06-150400.11.30.1
-  # Drivers
-  # rationale: Necessary for Mellanox device tools.
-  - kernel-mft-mlnx-kmp-default=4.21.0_k5.14.21_150400.22-1.sles15sp4
-  # rationale: Necessary for advanced QLogic support (CASMTRIAGE-5033)
-  - qlgc-fastlinq-kmp-default=8.72.4.1_k5.14.21_150400.22-1.sles15sp4
-  # rationale: Necessary for collecting hardware information.
-  - lshw=B.02.19.2+git.20230320-150200.3.15.4
-  # rationale: Necessary for inspecting, configuring, and upgrading Mellanox devices.
-  # mft: DO NOT INSTALL MFT FROM THE SPP REPO, NEVER APPEND "slesXspY"
-  - mft=4.21.0-99
-patterns:
+- name: Install packages
+  ansible.builtin.include_tasks:
+    file: packages.yml
+    apply:
+      tags: packages
+  tags:
+    - never
+    - packages

--- a/roles/packages_csm/tasks/packages.yml
+++ b/roles/packages_csm/tasks/packages.yml
@@ -1,0 +1,132 @@
+#
+# MIT License
+#
+# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+---
+- name: Debian Packages
+  when: ansible_distribution_file_variety == "Debian"
+  block:
+
+    - name: Load apt package list
+      ansible.builtin.include_vars:
+        dir: packages
+        files_matching: "{{ ansible_distribution_file_variety | lower }}.yml"
+      tags:
+        - always
+
+    - name: Install packages
+      ansible.builtin.apt:
+        allow_downgrade: true
+        name: "{{ packages }}"
+        state: present
+        install_recommends: false
+
+    - name: Load architecture specific package list(s)
+      ansible.builtin.include_vars:
+        dir: packages
+        files_matching: "{{ ansible_distribution_file_variety | lower }}-{{ ansible_architecture }}.yml"
+      tags:
+        - always
+      register: result
+
+    - name: Install architecture specific packages
+      ansible.builtin.apt:
+        allow_downgrade: true
+        name: "{{ packages }}"
+        state: present
+        install_recommends: false
+      when: result.ansible_included_var_files | length != 0
+
+- name: RHEL Packages
+  when: ansible_distribution_file_variety == "RedHat"
+  block:
+
+    - name: Load yum package list
+      ansible.builtin.include_vars:
+        dir: packages
+        files_matching: "{{ ansible_distribution_file_variety | lower }}.yml"
+      tags:
+        - always
+
+    - name: Install packages
+      ansible.builtin.yum:
+        allow_downgrade: true
+        name: "{{ packages }}"
+        state: present
+        update_cache: false
+
+    - name: Load architecture specific package list(s)
+      ansible.builtin.include_vars:
+        dir: packages
+        files_matching: "{{ ansible_distribution_file_variety | lower }}-{{ ansible_architecture }}.yml"
+      tags:
+        - always
+      register: result
+
+    - name: Install architecture specific packages
+      ansible.builtin.yum:
+        allow_downgrade: true
+        name: "{{ packages }}"
+        state: present
+        update_cache: false
+      when: result.ansible_included_var_files | length != 0
+
+- name: SUSE Packages
+  when: ansible_distribution_file_variety == "SUSE"
+  block:
+  # NOTE: Never set force_resolution to true, always inspect the error(s). Usually a package is obsoleting another, and one can be removed from our lists.
+
+    - name: Load zypper package list
+      ansible.builtin.include_vars:
+        dir: packages
+        files_matching: "{{ ansible_distribution_file_variety | lower }}.yml"
+      tags:
+        - always
+
+    - name: Install packages
+      community.general.zypper:
+        allow_vendor_change: true
+        disable_recommends: true
+        force_resolution: false
+        name: "{{ packages }}"
+        oldpackage: true
+        state: present
+        update_cache: false
+
+    - name: Load architecture specific package list(s)
+      ansible.builtin.include_vars:
+        dir: packages
+        files_matching: "{{ ansible_distribution_file_variety | lower }}-{{ ansible_architecture }}.yml"
+      tags:
+        - always
+      register: result
+
+    - name: Install architecture specific packages
+      community.general.zypper:
+        allow_vendor_change: true
+        disable_recommends: true
+        force_resolution: false
+        name: "{{ packages }}"
+        oldpackage: true
+        state: present
+        update_cache: false
+      when: result.ansible_included_var_files | length != 0

--- a/roles/packages_csm/vars/packages/suse.yml
+++ b/roles/packages_csm/vars/packages/suse.yml
@@ -22,50 +22,31 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 ---
-# NOTE: This list is incomplete, at this time there is no base image for Debian to use as a test.
-# TODO: Add pins
 packages:
-  # NTP
-  - cron
-  # Partitioning / bootloader /dracut
-  # TODO: No biosdevname
-  # TODO: no checkmedia
-  - cryptsetup
-  - dmraid
-  - dosfstools
-  - fdisk
-  - gdisk
-  - grub2
-  - iproute2
-  - lvm2
-  - mdadm
-  - mtools
-  - nvme-cli
-  - parted
-  - pciutils
-  - squashfs-tools-ng
-  - tpm2-abrmd
-  - tpm2-tools
-  - xfsprogs
-  - xfsprogs
-  - xorriso
-  # kdump
-  - crash
-  # Google Compute
-  - google-guest-agent
-  - google-guest-configs
-  - google-guest-oslogin
-  # user tools
-  - bash-completion
-  - emacs
-  - ethtool
-  - htop
-  - jq
-  - ledmon
-  - lshw
-  - lsscsi
-  - rsync
-  - tmux
-  - unzip
-  - vim
-  - zip
+  # Python
+  - craycli=0.82.6-1
+  - csm-auth-utils=1.0.0-1
+  - csm-node-heartbeat=2.0-3
+  - csm-node-identity=1.0.20-1
+  - python3-Jinja2=2.10.1-3.10.2
+  - python3-MarkupSafe=1.0-1.29
+  - python3-PyYAML=5.4.1-1.1
+  - python3-boto3=1.26.89-150200.23.12.1
+  - python3-click=7.0-1.27
+  - python3-colorama=0.4.4-5.4.1
+  - python3-defusedxml=0.6.0-1.42
+  - python3-dmidecode=3.12.2-150400.14.3.1
+  - python3-gobject=3.42.2-150400.3.3.2
+  - python3-ipaddr=2.1.11-2.24
+  - python3-kubernetes=8.0.1-150100.3.7.1
+  - python3-lxml=4.7.1-150200.3.10.1
+  - python3-netaddr=0.7.19-1.17
+  - python3-pexpect=4.8.0-150400.13.6
+  - python3-pyroute2=0.5.10-3.3.1
+  - python3-requests-oauthlib=0.8.0-3.4.1
+  - python3-requests=2.24.0-6.10.2
+  - python3-rpm=4.14.3-150300.55.1
+  - python3-six=1.14.0-12.1
+  - python3-urllib3=1.25.10-9.14.1
+  - spire-agent=1.5.5-1.7
+patterns:

--- a/roles/packages_csm/vars/services/suse.yml
+++ b/roles/packages_csm/vars/services/suse.yml
@@ -22,50 +22,22 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 ---
-# NOTE: This list is incomplete, at this time there is no base image for Debian to use as a test.
-# TODO: Add pins
-packages:
-  # NTP
-  - cron
-  # Partitioning / bootloader /dracut
-  - biosdevname
-  # TODO: no checkmedia
-  - cryptsetup
-  - device-mapper
-  - dosfstools
-  - fdisk
-  - gdisk
-  - grub2-efi-x64
-  - grub2-efi-x64-modules
-  - iproute2
-  - lvm2
-  - mdadm
-  - mtools
-  - nvme-cli
-  - parted
-  - pciutils
-  - squashfs-tools
-  - tpm2-abrmd
-  - tpm2-tools
-  - xfsprogs
-  - xorriso
-  # kdump
-  - crash
-  # Google Compute
-  - google-guest-agent
-  - google-guest-configs
-  - google-guest-oslogin
-  # user tools
-  - bash-completion
-  - emacs
-  - ethtool
-  - htop
-  - jq
-  - ledmon
-  - lshw
-  - lsscsi
-  - rsync
-  - tmux
-  - unzip
-  - vim
-  - zip
+services:
+  - enabled: true
+    name: cloud-config.service
+    state: stopped
+  - enabled: true
+    name: cloud-init.service
+    state: stopped
+  - enabled: true
+    name: cloud-init-local.service
+    state: stopped
+  - enabled: true
+    name: cloud-final.service
+    state: stopped
+  - enabled: true
+    name: csm-node-identity.service
+    state: stopped
+  - enabled: false
+    name: spire-agent.service
+    state: stopped

--- a/roles/packages_user/tasks/main.yml
+++ b/roles/packages_user/tasks/main.yml
@@ -22,25 +22,11 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 ---
-packages:
-  # rationale: Necessary for standardized network interface device names.
-  - biosdevname=0.7.3-5.3.1
-  # rationale: A dependency of SLES's GRUB package.
-  - grub2-branding-SLE=15-150400.38.3.1
-  # rationale: Provides a boot loader for booting into Linux.
-  - grub2=2.06-150400.11.30.1
-  # rationale: A dependency needed for the x86_64 EFI GRUB boot loader.
-  - grub2-i386-pc=2.06-150400.11.30.1
-  # rationale: Necessary for creating and managing an x86_64 EFI GRUB boot loader.
-  - grub2-x86_64-efi=2.06-150400.11.30.1
-  # Drivers
-  # rationale: Necessary for Mellanox device tools.
-  - kernel-mft-mlnx-kmp-default=4.21.0_k5.14.21_150400.22-1.sles15sp4
-  # rationale: Necessary for advanced QLogic support (CASMTRIAGE-5033)
-  - qlgc-fastlinq-kmp-default=8.72.4.1_k5.14.21_150400.22-1.sles15sp4
-  # rationale: Necessary for collecting hardware information.
-  - lshw=B.02.19.2+git.20230320-150200.3.15.4
-  # rationale: Necessary for inspecting, configuring, and upgrading Mellanox devices.
-  # mft: DO NOT INSTALL MFT FROM THE SPP REPO, NEVER APPEND "slesXspY"
-  - mft=4.21.0-99
-patterns:
+- name: Install packages
+  ansible.builtin.include_tasks:
+    file: packages.yml
+    apply:
+      tags: packages
+  tags:
+    - never
+    - packages

--- a/roles/packages_user/tasks/packages.yml
+++ b/roles/packages_user/tasks/packages.yml
@@ -1,0 +1,132 @@
+#
+# MIT License
+#
+# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+---
+- name: Debian Packages
+  when: ansible_distribution_file_variety == "Debian"
+  block:
+
+    - name: Load apt package list
+      ansible.builtin.include_vars:
+        dir: packages
+        files_matching: "{{ ansible_distribution_file_variety | lower }}.yml"
+      tags:
+        - always
+
+    - name: Install packages
+      ansible.builtin.apt:
+        allow_downgrade: true
+        name: "{{ packages }}"
+        state: present
+        install_recommends: false
+
+    - name: Load architecture specific package list(s)
+      ansible.builtin.include_vars:
+        dir: packages
+        files_matching: "{{ ansible_distribution_file_variety | lower }}-{{ ansible_architecture }}.yml"
+      tags:
+        - always
+      register: result
+
+    - name: Install architecture specific packages
+      ansible.builtin.apt:
+        allow_downgrade: true
+        name: "{{ packages }}"
+        state: present
+        install_recommends: false
+      when: result.ansible_included_var_files | length != 0
+
+- name: RHEL Packages
+  when: ansible_distribution_file_variety == "RedHat"
+  block:
+
+    - name: Load yum package list
+      ansible.builtin.include_vars:
+        dir: packages
+        files_matching: "{{ ansible_distribution_file_variety | lower }}.yml"
+      tags:
+        - always
+
+    - name: Install packages
+      ansible.builtin.yum:
+        allow_downgrade: true
+        name: "{{ packages }}"
+        state: present
+        update_cache: false
+
+    - name: Load architecture specific package list(s)
+      ansible.builtin.include_vars:
+        dir: packages
+        files_matching: "{{ ansible_distribution_file_variety | lower }}-{{ ansible_architecture }}.yml"
+      tags:
+        - always
+      register: result
+
+    - name: Install architecture specific packages
+      ansible.builtin.yum:
+        allow_downgrade: true
+        name: "{{ packages }}"
+        state: present
+        update_cache: false
+      when: result.ansible_included_var_files | length != 0
+
+- name: SUSE Packages
+  when: ansible_distribution_file_variety == "SUSE"
+  block:
+  # NOTE: Never set force_resolution to true, always inspect the error(s). Usually a package is obsoleting another, and one can be removed from our lists.
+
+    - name: Load zypper package list
+      ansible.builtin.include_vars:
+        dir: packages
+        files_matching: "{{ ansible_distribution_file_variety | lower }}.yml"
+      tags:
+        - always
+
+    - name: Install packages
+      community.general.zypper:
+        allow_vendor_change: true
+        disable_recommends: true
+        force_resolution: false
+        name: "{{ packages }}"
+        oldpackage: true
+        state: present
+        update_cache: false
+
+    - name: Load architecture specific package list(s)
+      ansible.builtin.include_vars:
+        dir: packages
+        files_matching: "{{ ansible_distribution_file_variety | lower }}-{{ ansible_architecture }}.yml"
+      tags:
+        - always
+      register: result
+
+    - name: Install architecture specific packages
+      community.general.zypper:
+        allow_vendor_change: true
+        disable_recommends: true
+        force_resolution: false
+        name: "{{ packages }}"
+        oldpackage: true
+        state: present
+        update_cache: false
+      when: result.ansible_included_var_files | length != 0

--- a/roles/packages_user/vars/packages/suse.yml
+++ b/roles/packages_user/vars/packages/suse.yml
@@ -1,0 +1,88 @@
+#
+# MIT License
+#
+# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+---
+packages:
+  - at=3.2.2-150400.4.3.10
+  - bc=1.07.1-11.37
+  - bind-utils=9.16.42-150400.5.27.1
+  - bsdtar=3.5.1-150400.3.12.1
+  - ca-certificates-mozilla=2.60-150200.27.1
+  - ca-certificates=2+git20210309.21162a6-2.1
+  - cron=4.2-150400.84.3.1
+  - curl=8.0.1-150400.5.23.1
+  - dmidecode=3.4-150400.16.8.1
+  - dump=0.4b47-150400.1.10
+  - ebtables=2.0.11-1.1
+  - elfutils-lang=0.185-150400.5.3.1
+  - elfutils=0.185-150400.5.3.1
+  - emacs=27.2-150400.3.6.1
+  - expect=5.45.4-3.3.1
+  - fontconfig=2.13.1-150400.1.4
+  - fonts-config=20200609+git0.42e2b1b-4.7.1
+  - fping=4.0-4.3.2
+  - fuse=2.9.7-3.3.1
+  - gdb=12.1-150400.15.6.1
+  - genders=1.27.3-150400.8.7
+  - git-core=2.35.3-150300.10.27.1
+  - gnuplot=5.4.3-150400.1.6
+  - hdparm=9.62-150400.1.7
+  - helm-bash-completion=3.11.2-150000.1.21.1
+  - helm-zsh-completion=3.11.2-150000.1.21.1
+  - helm=3.11.2-150000.1.21.1
+  - hpe-yq=4.33.3-1
+  - htop=3.0.5-bp154.1.30
+  - hwloc=2.5.0-150400.1.9
+  - issue-generator=1.7-1.17
+  - libasm1=0.185-150400.5.3.1
+  - libcanberra-gtk0=0.30-150400.13.10
+  - libdw1=0.185-150400.5.3.1
+  - libelf-devel=0.185-150400.5.3.1
+  - libelf1=0.185-150400.5.3.1
+  - libfreebl3-hmac=3.79.4-150400.3.29.1
+  - libfreebl3=3.79.4-150400.3.29.1
+  - liblldp_clif1=1.1+44.0f781b4162d3-3.3.1
+  - libopenssl1_1=1.1.1l-150400.7.42.1
+  - libpwquality1=1.4.4-150400.15.4
+  - libstoragemgmt=1.8.5-3.3.1
+  - libunwind-devel=1.5.0-4.5.1
+  - openssl-1_1=1.1.1l-150400.7.42.1
+  - perf=5.14.21-150400.44.13.1
+  - perl-File-BaseDir=0.09-bp154.1.25
+  - perl-File-Which=1.22-1.22
+  - perl-MailTools=2.19-1.20
+  - perl-doc=5.26.1-150300.17.11.1
+  - pixz=1.0.6-1.13
+  - postfix=3.5.9-5.9.2
+  - rsyslog=8.2106.0-150400.5.11.1
+  - screen=4.6.2-5.3.1
+  - tar=1.34-150000.3.31.1
+  - tmux=3.1c-bp152.2.3.1
+  - unixODBC=2.3.9-150400.14.5
+  - unzip=6.00-150000.4.11.1
+  - vim-data=9.0.1443-150000.5.43.1
+  - vim=9.0.1443-150000.5.43.1
+  - yq-bash-completion=4.18.1-bp154.1.17
+  - yq-zsh-completion=4.18.1-bp154.1.17
+  - zip=3.0-2.22
+patterns:

--- a/scripts/rpm-functions.sh
+++ b/scripts/rpm-functions.sh
@@ -266,7 +266,6 @@ function update-package-version() {
     local package="$2"
     local current_version="$3"
     local new_version="$4"
-
     sed -e "s/$package=$current_version/$package=$new_version/" -i "$packages_path"
 }
 

--- a/scripts/update-package-versions.sh
+++ b/scripts/update-package-versions.sh
@@ -211,7 +211,6 @@ else
   DOCKER_TTY_ARG="-it"
 fi
 
-set -x
 docker run --platform $DOCKER_ARCH -e ARCH=$ARCH $DOCKER_TTY_ARG --rm -v "$(realpath "$SOURCE_DIR"):/app" -v "$(realpath "$PACKAGES_FILE"):/packages" --init $DOCKER_CACHE_IMAGE bash -c "
   set -e
   source /app/scripts/rpm-functions.sh

--- a/scripts/update-package-versions.sh
+++ b/scripts/update-package-versions.sh
@@ -211,6 +211,7 @@ else
   DOCKER_TTY_ARG="-it"
 fi
 
+set -x
 docker run --platform $DOCKER_ARCH -e ARCH=$ARCH $DOCKER_TTY_ARG --rm -v "$(realpath "$SOURCE_DIR"):/app" -v "$(realpath "$PACKAGES_FILE"):/packages" --init $DOCKER_CACHE_IMAGE bash -c "
   set -e
   source /app/scripts/rpm-functions.sh


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Relates to: Hypervisor and VM work

#### Issue Type

<!--- Delete un-needed bullets -->

- RFE Pull Request

<!--- words; describe what this change is and what it is for. -->
The hypervisor and new VM images are pulling in node-images-base, which is installing several items that we do not want in those new images.

In an attempt to appease the new and current collection of images, this change breaks out the CSM packages and a curated list of user-space packages into their own, respective roles.

The CSM packages are now opt-in, as well as the user-space packages. This will significantly slim down the CVE footprint of our new images, while allowing us to have a common ground for all images. node-images-base now only contains a curated, bare-minimum set of packages. Each package in node-images-base also has its own rationale memo.

### Hypervisor Package Removals

***NOTE*** Development within a booted hypervisor will be more difficult without the aide of adding Artifactory repositories:

- `bsdtar`
- `curl`
- `git-core`
- `bind-utils`
- `emacs`
- `helm`
- `tar`
- `tmux`
- `screen`
- `unzip`
- `vim`
- `yq`
- `zip`

### Hypervisor Package Additions

The following packages have been added to facilitate development.

- `crucible` (this replaces the `pip install`ed `crucible` from the pipeline)
- `virt-install` for the current management VM install work (MTL-2182)

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [x] I have tested this by building an image using this branch HEAD, or this is does not pertain to the node-images pipeline.
- [ ] I tested this on internal system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
- [ ] I tested this on a vshasta system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
