### PR TITLE
Change cray artifacts to return more than 1000 files (CASMPET-6168)

### DIFF
--- a/roles/packages_csm/vars/packages/suse.yml
+++ b/roles/packages_csm/vars/packages/suse.yml
@@ -24,7 +24,7 @@
 ---
 packages:
   # Python
-  - craycli=0.82.6-1
+  - craycli=0.82.7-1
   - csm-auth-utils=1.0.0-1
   - csm-node-heartbeat=2.0-3
   - csm-node-identity=1.0.20-1


### PR DESCRIPTION
### Summary and Scope

Use boto3 pagination api to fully list bucket contents.

### Issues and Related PRs

* https://jira-pro.it.hpe.com:8443/browse/CASMPET-6168

### Testing

mug:

Before:

```
cray artifacts list thanos | grep ^Key | wc -l
1000

cray artifacts list velero | grep ^Key | wc -l
1000
```

After:
```
cray artifacts list thanos | grep ^Key | wc -l
1583

cray artifacts list velero | grep ^Key | wc -l
2913
```

Was a fresh Install tested? N
Was an Upgrade tested?      N - N/A
Was a Downgrade tested?     N - N/A
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

### Risks and Mitigations

Low

### Requires:

* Nothing
