### PR TITLE
CASMHMS-3700 Bump hpe-csm-scripts to v0.6.0

### DIFF
--- a/roles/node_images_ncn_common/vars/packages/suse.yml
+++ b/roles/node_images_ncn_common/vars/packages/suse.yml
@@ -79,7 +79,7 @@ packages:
   - cray-kubectl-kubelogin-plugin=1.25.2-1
   - goss-servers=1.16.42-1
   - hpe-csm-goss-package=0.3.21-hpe3
-  - hpe-csm-scripts=0.5.5-1
+  - hpe-csm-scripts=0.6.0-1
   - loftsman=1.2.0-3
   - manifestgen=1.3.9-1
   # CM cli


### PR DESCRIPTION
### Summary and Scope

This change adds new HMNFD Tavern tests to the HMS CT test wrapper. Previously only basic smoke tests were implemented but now additional functional tests are deployed during CT test runs. This change is targeting CSM-1.6.

### Issues and Related PRs

* Partially resolves CASMHMS-3700.

### Testing

New Tavern tests passing in GitHub actions. Also deployed updated tests on Dorian vShasta system running CSM-1.5.0-beta.10 and verified they passed.

Was a fresh Install tested? N
Was an Upgrade tested? Y
Was a Downgrade tested? Y

### Risks and Mitigations

Low risk, adds test coverage for HMNFD.