### PR TITLE
Adds more needed packages for management-vm

### DIFF
--- a/roles/node_images_base/vars/packages/suse.yml
+++ b/roles/node_images_base/vars/packages/suse.yml
@@ -63,6 +63,8 @@ packages:
   - ledmon=0.94-150400.5.5
   # rationale: Necessary for multiple device (MD) software RAID.
   - mdadm=4.1-150300.24.27.1
+  # rationale: Necessary for ISO emulation
+  - mkisofs=3.02~a09-4.6.1
   # rationale: Necessary for constructing boot loader images.
   - mtools=4.0.35-150400.1.11
   # rationale: Necessary for NVME control in a failed initramFS (required by dracut).

--- a/roles/node_images_management/vars/packages/suse.yml
+++ b/roles/node_images_management/vars/packages/suse.yml
@@ -27,7 +27,11 @@ packages:
   - cloud-init-config-suse=23.1-150100.8.63.5
   - cloud-init=23.1-150100.8.63.5
   - cray-site-init=1.32.0-1
+  - libvirt-client=8.0.0-150400.7.6.1
+  - libvirt-devel=8.0.0-150400.7.6.1
+  - libvirt=8.0.0-150400.7.6.1
   - ilorest=4.2.0.0-20
+  - metal-init=1.4.2-1
   - metal-ipxe=2.4.4-1
   - metal-nexus=1.2.3-1
   - metal-observability=1.0.9-1


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: MTL-2179

#### Issue Type

<!--- Delete un-needed bullets -->

- RFE Pull Request

<!--- words; describe what this change is and what it is for. -->
`mkisofs` is needed for the cloud-init ISO generation by some VM tools such as `pulumi` and `virsh`.

Also adds `metal-init` and `libvirt` to the Management VM.

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I have tested this by building an image using this branch HEAD, or this is does not pertain to the node-images pipeline.
- [ ] I tested this on internal system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
- [ ] I tested this on a vshasta system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
