### PR TITLE
MTL-2191 1.5

### DIFF
--- a/roles/node_images_base/vars/packages/suse.yml
+++ b/roles/node_images_base/vars/packages/suse.yml
@@ -31,23 +31,23 @@ packages:
   # rationale: Necessary for viewing and managing routing tables.
   - iproute2=5.14-150400.1.8
   # rationale: Dependency for daemon necessities.
-  - libsystemd0=249.16-150400.8.28.3
+  - libsystemd0=249.16-150400.8.25.7
   # rationale: Dependency for daemon necessities.
-  - libudev1=249.16-150400.8.28.3
+  - libudev1=249.16-150400.8.25.7
   # rationale: Dependency for daemon necessities.
-  - systemd-coredump=249.16-150400.8.28.3
+  - systemd-coredump=249.16-150400.8.25.7
   # rationale: Dependency for daemon necessities.
-  - systemd-lang=249.16-150400.8.28.3
+  - systemd-lang=249.16-150400.8.25.7
   # rationale: Necessary for daemons.
-  - systemd-sysvinit=249.16-150400.8.28.3
+  - systemd-sysvinit=249.16-150400.8.25.7
   # rationale: Necessary for daemons.
-  - systemd=249.16-150400.8.28.3
+  - systemd=249.16-150400.8.25.7
   # rationale: Necessary for TPM2.
   - tpm2.0-abrmd=2.4.0-150400.1.6
   # rationale: Necessary for TPM2.
   - tpm2.0-tools=5.2-150400.4.6
   # rationale: Necessary for hardware interfaces.
-  - udev=249.16-150400.8.28.3
+  - udev=249.16-150400.8.25.7
   #
   ## Filesystems and block device helpers
   #

--- a/roles/node_images_base/vars/packages/suse.yml
+++ b/roles/node_images_base/vars/packages/suse.yml
@@ -135,6 +135,8 @@ packages:
   - tcpdump=4.99.1-150400.1.8
   # rationale: Necessary for triaging and debugging packet routes.
   - traceroute=2.0.21-1.29
+  # rationale: Provides `lsblk` and other useful block device tools.
+  - util-linux-systemd=2.37.2-150400.8.17.1
   # rationale: Necessary for viewing, dumping, and inspecting USB devices.
   - usbutils=014-3.3.1
   # rationale: Necessary for resolving where an application is actually running from.


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: MTL-2191
- Relates to: https://github.com/Cray-HPE/metal-provision/commit/d338583bb4f61e51ae55c57c548172cbfc6364a8

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->
[SUSE-RU-2023:2240-1](https://www.suse.com/support/update/announcement/2023/suse-ru-20232240-1/) brought in a new systemd and udev flavor that contains the following patches:
1. [`0005-udev-create-default-symlinks-for-primary-cd_dvd-driv.patch`](https://build.opensuse.org/package/view_file/SUSE:SLE-15-SP4:Update/systemd/0005-udev-create-default-symlinks-for-primary-cd_dvd-driv.patch?expand=1)
1. [`1001-udev-use-lock-when-selecting-the-highest-priority-de.patch`](https://build.opensuse.org/package/view_file/SUSE:SLE-15-SP4:Update/systemd/1001-udev-use-lock-when-selecting-the-highest-priority-de.patch?expand=1)

The second patch, `1001-udev-use-lock-when-selecting-the-highest-priority-de.patch`, changes the handling of device symlink priorities when multiple devices claim the same symlink (see Update v3 in the patch file). This appears to cause a regression to https://github.com/systemd/systemd/commit/19212f27816686a5cac2c965301cea8624ac467f which was responsible for fixing this problem for ISOs, where the parent device and the ISO partition have the same FSLabel.

By changing the priorities of the devices, the wrong device is getting a symlink and getting mounted, when the parent device is mounted instead none of the partitions may be mounted.

```bash
sh-4.4# ls -l /dev/disk/by-label/
total 0
lrwxrwxrwx 1 root root 10 Jul  9 17:12 BOOT -> ../../sdd2
lrwxrwxrwx 1 root root  9 Jul  9 17:12 CRAYLIVE -> ../../sdd
lrwxrwxrwx 1 root root 10 Jul  9 17:12 VMSTORE -> ../../sdc1
lrwxrwxrwx 1 root root 10 Jul  9 17:12 cow -> ../../sdd3
lrwxrwxrwx 1 root root 10 Jul  9 17:12 data -> ../../sdd4
sh-4.4# lsblk /dev/sdd
NAME   MAJ:MIN RM   SIZE RO TYPE MOUNTPOINTS
sdd         8:48   1   239G  0 disk  /run/initramfs/live
├─sdd1      8:49   1   1.4G  0 part
├─sdd2      8:50   1    10M  0 part
├─sdd3      8:51   1  46.6G  0 part
└─sdd4      8:52   1 191.1G  0 part
```

When we roll back to the previous version of systemd, we observe the expected behavior:

```bash
sh-4.4# ls -l /dev/disk/by-label/
total 0
lrwxrwxrwx 1 root root 10 Jul  9 17:33 BOOT -> ../../sdd2
lrwxrwxrwx 1 root root 10 Jul  9 17:33 CRAYLIVE -> ../../sdd1
lrwxrwxrwx 1 root root 10 Jul  9 17:33 VMSTORE -> ../../sdb1
lrwxrwxrwx 1 root root 10 Jul  9 17:33 cow -> ../../sdd3
lrwxrwxrwx 1 root root 10 Jul  9 17:33 data -> ../../sdd4
sh-4.4# lsblk /dev/sdd
NAME   MAJ:MIN RM   SIZE RO TYPE MOUNTPOINTS
sdd      8:48   1   239G  0 disk
├─sdd1   8:49   1   1.4G  0 part /run/initramfs/live
├─sdd2   8:50   1    10M  0 part
├─sdd3   8:51   1  46.6G  0 part /run/initramfs/overlayfs
└─sdd4   8:52   1 191.1G  0 part
```

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [x] I have tested this by building an image using this branch HEAD, or this is does not pertain to the node-images pipeline.
- [x] I tested this on internal system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
- [ ] I tested this on a vshasta system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
