### PR TITLE
Add `vim` to base

### DIFF
--- a/roles/node_images_base/vars/packages/suse.yml
+++ b/roles/node_images_base/vars/packages/suse.yml
@@ -139,6 +139,10 @@ packages:
   - util-linux-systemd=2.37.2-150400.8.17.1
   # rationale: Necessary for viewing, dumping, and inspecting USB devices.
   - usbutils=014-3.3.1
+  # rationale: Necessary for vim.
+  - vim-data=9.0.1572-150000.5.46.1
+  # rationale: Necessary for basic editing.
+  - vim=9.0.1572-150000.5.46.1
   # rationale: Necessary for resolving where an application is actually running from.
   - which=2.21-2.20
 patterns:

--- a/roles/packages_user/vars/packages/suse.yml
+++ b/roles/packages_user/vars/packages/suse.yml
@@ -80,8 +80,6 @@ packages:
   - tmux=3.1c-bp152.2.3.1
   - unixODBC=2.3.9-150400.14.5
   - unzip=6.00-150000.4.11.1
-  - vim-data=9.0.1572-150000.5.46.1
-  - vim=9.0.1572-150000.5.46.1
   - yq-bash-completion=4.18.1-bp154.1.17
   - yq-zsh-completion=4.18.1-bp154.1.17
   - zip=3.0-2.22


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

#### Issue Type

<!--- Delete un-needed bullets -->

- RFE Pull Request

<!--- words; describe what this change is and what it is for. -->
Without `vim` in the hypervisor, there is no way to create or edit files without using `sed` and `cat << EOF > file`. Moving `vim` to the base role will ensure it's installed everywhere without needing every other user package from `packages_user`.

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I have tested this by building an image using this branch HEAD, or this is does not pertain to the node-images pipeline.
- [ ] I tested this on internal system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
- [ ] I tested this on a vshasta system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
