### PR TITLE
Fix nmn pool test to attempt to find input file if sls not up yet (CASMINST-6527)

### DIFF
--- a/roles/node_images_ncn_common/vars/packages/suse.yml
+++ b/roles/node_images_ncn_common/vars/packages/suse.yml
@@ -77,7 +77,7 @@ packages:
   - cloud-init=21.4-1
   - cray-kubectl-hns-plugin=1.0.1-1
   - cray-kubectl-kubelogin-plugin=1.25.2-1
-  - goss-servers=1.16.42-1
+  - goss-servers=1.16.45-1
   - hpe-csm-goss-package=0.3.21-hpe3
   - hpe-csm-scripts=0.6.0-1
   - loftsman=1.2.0-3


### PR DESCRIPTION
### Summary and Scope

Enhance goss-k8s-pods-ips-in-nmn-pool.yaml test to attempt to find sls file on filesystem if sls not available, as well as use nmap to determine if IP is in subnet range.

### Issues and Related PRs

* https://jira-pro.it.hpe.com:8443/browse/CASMINST-6527

### Testing

Drax:

```
ncn-m001:~/brad # export GOSS_BASE=/opt/cray/tests/install/ncn; goss -g /opt/cray/tests/install/ncn/tests/goss-k8s-pods-ips-in-nmn-pool-brad.yaml --vars=/opt/cray/tests/install/ncn/vars/variables-ncn.yaml validate
..

Total Duration: 1.660s
Count: 2, Failed: 0, Skipped: 0
```

```
ncn-m001:~/brad # ./check_goss_k8s_pods_ips_in_nmn_pool.sh
Successfully called sls search networks...
PASS: All K8S pod IPs are in the NMN Bootstrap DNCP Subnet
```

```
ncn-m001:~/brad # ./check_goss_k8s_pods_ips_in_nmn_pool.sh
Failed to talk to sls, looking for sls_input_file.json on the filesystem...
Found sls_input_file.json at /metal/bootstrap/prep/drax/sls_input_file.json, proceeding...
PASS: All K8S pod IPs are in the NMN Bootstrap DNCP Subnet
```

```
ncn-m001:~/brad # ./check_goss_k8s_pods_ips_in_nmn_pool.sh
Failed to talk to sls, looking for sls_input_file.json on the filesystem...
Unable to find sls_input_file.json on the filesystem, defaulting subnet to 10.252.1.0/17...
PASS: All K8S pod IPs are in the NMN Bootstrap DNCP Subnet
```


Was a fresh Install tested? N
Was an Upgrade tested?      N - N/A
Was a Downgrade tested?     N - N/A
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

### Risks and Mitigations

Low

### Requires:

* Nothing
