### PR TITLE
MTL-2205 Pin troublesome packages

### DIFF
--- a/roles/packages_user/vars/packages/suse.yml
+++ b/roles/packages_user/vars/packages/suse.yml
@@ -56,15 +56,22 @@ packages:
   - issue-generator=1.13-150100.3.3.1
   - libasm1=0.185-150400.5.3.1
   - libcanberra-gtk0=0.30-150400.13.10
+  - libdebuginfod1=0.185-150400.5.3.1
   - libdw1=0.185-150400.5.3.1
   - libelf-devel=0.185-150400.5.3.1
   - libelf1=0.185-150400.5.3.1
   - libfreebl3=3.90-150400.3.32.1
+  - libldap-2_4-2-2.4.46-150200.14.14.1
+  - libldap-data-2.4.46-150200.14.14.1
   - liblldp_clif1=1.1+44.0f781b4162d3-3.3.1
   - libopenssl1_1=1.1.1l-150400.7.45.1
   - libpwquality1=1.4.4-150400.15.4
+  - libsoftokn3=3.90-150400.3.32.1
   - libstoragemgmt=1.8.5-3.3.1
   - libunwind-devel=1.5.0-4.5.1
+  - mozilla-nss-certs=3.90-150400.3.32.1
+  - mozilla-nss-tools=3.90-150400.3.32.1
+  - mozilla-nss=3.90-150400.3.32.1
   - openssl-1_1=1.1.1l-150400.7.45.1
   - perf=5.14.21-150400.44.13.1
   - perl-File-BaseDir=0.09-bp154.1.25


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: MTL-2205

#### Issue Type

<!--- Delete un-needed bullets -->

- RFE Pull Request

<!--- words; describe what this change is and what it is for. -->
Pins the:
- elf packages
- libldap packages
- and mozilla-nss packages

All of which have caused build issues for images or CSM. This pins the full set of packages to prevent Zypper from complaining, so the entire set is downgraded without conflicts.

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I have tested this by building an image using this branch HEAD, or this is does not pertain to the node-images pipeline.
- [ ] I tested this on internal system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
- [ ] I tested this on a vshasta system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
