### PR TITLE
 Change cpu throttle script to be k8s version agnostic (CASMTRIAGE-5697)

### DIFF
--- a/roles/node_images_ncn_kubernetes/vars/packages/suse.yml
+++ b/roles/node_images_ncn_kubernetes/vars/packages/suse.yml
@@ -30,7 +30,7 @@ packages:
   # CSM
   # platform-utils is also installed by cloud-init. However, we need to *also* bake it in
   # for proper vshasta-v2 functionality.
-  - platform-utils=1.6.2-1
+  - platform-utils=1.6.3-1
   # Metal
   - dracut-metal-dmk8s=2.1.0-1
   - dracut-metal-luksetcd=2.1.0-1


### PR DESCRIPTION
### Summary and Scope

Change cpu throttle detection script to not assume kubectl output order.

### Issues and Related PRs

* https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-5697

### Testing

Dorian:

```
ncn-m001:~ # /opt/cray/platform-utils/detect_cpu_throttling.sh nls

Checking cray-nls-678b49ffdb-wbnkd
*** CPU throttling for containerid a41c13afb6624a2edcd56c3212e73f67c51a668d84ed212252c06f32360ddf5e: ***
nr_periods 1167749
nr_throttled 307
throttled_time 4771194407


Checking cray-nls-argo-workflows-server-85d4d8866d-tkw54
*** CPU throttling for containerid c63c012d528a43f6a321cb5dcdf870fbd82f0eb8db8c61bdd1f2e08d56017718: ***
nr_periods 1124931
nr_throttled 1
throttled_time 2555416


Checking cray-nls-argo-workflows-workflow-controller-66fcbc9679-hwgkd

Checking cray-nls-postgres-0
*** CPU throttling for containerid 7e027d0dc5bccabe32b4b0e495783b3de1b6f964f55824cd15fdde9818669133: ***
nr_periods 1245739
nr_throttled 1
throttled_time 5973792

*** CPU throttling for containerid 88d5ebcbbcfff0e2da6a2fcda3717675f465d6160e2f2256de53fead9e83ebbf: ***
nr_periods 708510
nr_throttled 11
throttled_time 258972531


Checking cray-nls-postgres-1
*** CPU throttling for containerid d59f68a1279406a4687a013d901b35a674cea0a43f0ecfdbdc200041bd7310fc: ***
nr_periods 1264026
nr_throttled 2
throttled_time 44411165

*** CPU throttling for containerid 635d6b514b05fd7155f8be2ee44b0d51a2f06ea48baac3e47c218bb77beee182: ***
nr_periods 970490
nr_throttled 5
throttled_time 38886588


Checking cray-nls-postgres-2
*** CPU throttling for containerid d2c31d6ee7438179655c10bbbe47185712a6128363c559d56f966964e0531e7a: ***
nr_periods 1170465
nr_throttled 2
throttled_time 138440860

*** CPU throttling for containerid 7f5c21dc4b7c70b317baee8de1feefb10fc18194d6a0ab438082546fb17579c6: ***
nr_periods 911909
nr_throttled 3
throttled_time 38196446
```


Was a fresh Install tested? N
Was an Upgrade tested?      N - N/A
Was a Downgrade tested?     N - N/A
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

### Risks and Mitigations

Low

### Requires:

* Nothing
