### PR TITLE
MTL-2192 Remove/overwrite Duplicate FSLabel

### DIFF
--- a/roles/node_images_base/files/scripts/metal/create-iso-artifact.sh
+++ b/roles/node_images_base/files/scripts/metal/create-iso-artifact.sh
@@ -127,6 +127,10 @@ function create-iso {
         -boot_image any efi_path=--interval:appended_partition_2:all:: \
         -boot_image any platform_id=0xef \
         -boot_image any emul_type=no_emulation
+
+    # Remove the duplicate label observed between the ISO and the ISO partition (MTL-2191, MTL-2192, SUSE #00697765)
+    echo -n 'ISO' | iconv -f utf8 -t UCS-2BE | dd bs=1 seek=$((0x9028)) conv=notrunc of="${iso}"
+
     # NOTE: Can't sign the ISO with the HPE key because it is too large. --create-signature could be used but this makes a unique key.
     tagmedia --md5 --check --pad 150 ${iso}
 }


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: MTL-2192

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->
The ISO has a duplicate label which is causing problems when booting from a USB when using systemd 249.16-150400.8.28.3 and newer. SUSE has changed the behavior of the 60-persistent-storage udev rules, which no longer plays nice with the implicitly set duplicate label.

Writing a different label to the first few sectors of the ISO prevents the duplicate label from appearing, and allows the correct partition to be selected.

This fix will allow us to pull in systemd/udev updates once again.

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I have tested this by building an image using this branch HEAD, or this is does not pertain to the node-images pipeline.
- [x] I tested this on internal system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
- [ ] I tested this on a vshasta system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
