### PR TITLE
Add smartmon configuration for node-exporter on storage nodes (CASMPET-6687)

### DIFF
--- a/roles/node_images_storage_ceph/vars/packages/suse.yml
+++ b/roles/node_images_storage_ceph/vars/packages/suse.yml
@@ -27,4 +27,5 @@ packages:
   - golang-github-prometheus-node_exporter=1.5.0-150100.3.23.2
   - libfmt8=8.0.1-150400.1.8
   - ses-release=7-64.1
+  - smart-mon=1.0.2-1
 patterns:


### PR DESCRIPTION
### Summary and Scope

Fresh install changes for smartmon on storage nodes for CSM 1.5

### Issues and Related PRs

* https://jira-pro.it.hpe.com:8443/browse/CASMPET-6687

### Testing

Deployed rpm to craystack, installed rpm on mug and ran the apply successfully.

Was a fresh Install tested? N
Was an Upgrade tested?      N - N/A
Was a Downgrade tested?     N - N/A
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

### Risks and Mitigations

Low

### Requires:

* Nothing
