### PR TITLE
Pin to better smart-mon rpm, enable and start the service (CASMTRIAGE-5697)

### DIFF
--- a/roles/node_images_storage_ceph/vars/packages/suse.yml
+++ b/roles/node_images_storage_ceph/vars/packages/suse.yml
@@ -27,5 +27,5 @@ packages:
   - golang-github-prometheus-node_exporter=1.5.0-150100.3.23.2
   - libfmt8=8.0.1-150400.1.8
   - ses-release=7-64.1
-  - smart-mon=1.0.2-1
+  - smart-mon=1.0.3-1
 patterns:

--- a/roles/node_images_storage_ceph/vars/services/suse.yml
+++ b/roles/node_images_storage_ceph/vars/services/suse.yml
@@ -41,3 +41,6 @@ services:
   - enabled: false
     name: spire-agent.service
     state: stopped
+  - enabled: true
+    name: smart.service
+    state: stopped


### PR DESCRIPTION
### Summary and Scope

Fix conflicts and refactor smartmon rpm

### Issues and Related PRs

* https://jira-pro.it.hpe.com:8443/browse/CASMPET-6687

### Testing

```

ncn-s001:~/brad # ./install.sh
Loading repository data...
Reading installed packages...
Resolving package dependencies...

The following 5 NEW packages are going to be installed:
  cephadm golang-github-prometheus-node_exporter libfmt8 ses-release smart-mon

The following NEW product is going to be installed:
  "SUSE Enterprise Storage 7"

The following 5 packages have no support information from their vendor:
  cephadm golang-github-prometheus-node_exporter libfmt8 ses-release smart-mon

5 new packages to install.
Overall download size: 96.8 KiB. Already cached: 8.6 MiB. After the operation, additional 19.4 MiB will be
used.
Continue? [y/n/v/...? shows all options] (y): y
Retrieving: cephadm-17.2.6.736+ge1900c40c6e-lp154.1.1.noarch (Plain RPM files cache)   (1/5),  83.7 KiB
Retrieving: smart-mon-1.0.3-1~fix_conflict~20230721173418.4778646.noarch (Plain RPM files cache)
                                                                                       (2/5),  13.1 KiB
smart-mon-1.0.3-1~fix_conflict~20230721173418.4778646.noarch.rpm:
    Package header is not signed!

smart-mon-1.0.3-1~fix_conflict~20230721173418.4778646.noarch (Plain RPM files cache): Signature verification failed [6-File is unsigned]
Abort, retry, ignore? [a/r/i] (a): i
In cache golang-github-prometheus-node_exporter-1.5.0-150100.3.23.2.x86_64.rpm         (3/5),   8.5 MiB
In cache libfmt8-8.0.1-150400.1.8.x86_64.rpm                                           (4/5),  75.5 KiB
In cache ses-release-7-64.1.x86_64.rpm                                                 (5/5),  10.8 KiB

Checking for file conflicts: ........................................................................[done]
(1/5) Installing: cephadm-17.2.6.736+ge1900c40c6e-lp154.1.1.noarch ..................................[done]
Removed /etc/systemd/system/multi-user.target.wants/smart.service.
(2/5) Installing: smart-mon-1.0.3-1~fix_conflict~20230721173418.4778646.noarch ......................[done]
Updating /etc/sysconfig/prometheus-node_exporter ...
(3/5) Installing: golang-github-prometheus-node_exporter-1.5.0-150100.3.23.2.x86_64 .................[done]
(4/5) Installing: libfmt8-8.0.1-150400.1.8.x86_64 ...................................................[done]
(5/5) Installing: ses-release-7-64.1.x86_64 .........................................................[done]
```

Was a fresh Install tested? N
Was an Upgrade tested?      N - N/A
Was a Downgrade tested?     N - N/A
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

### Risks and Mitigations

Low

### Requires:

* Nothing
