### PR TITLE
Upgrade openssh version for build fix.

### DIFF
--- a/roles/node_images_base/vars/packages/suse.yml
+++ b/roles/node_images_base/vars/packages/suse.yml
@@ -122,7 +122,7 @@ packages:
   # rationale: Necessary for link layer discovery protocol (LLDP) during early startup.
   - open-lldp=1.1+44.0f781b4162d3-3.3.1
   # rationale: Necessary for incoming and outgoing secure shells.
-  - openssh=8.4p1-150300.3.18.2
+  - openssh=8.4p1-150300.3.22.1
   # rationale: Necessary for viewing, dumping, and inspecting PCI devices.
   - pciutils=3.5.6-150300.13.3.1
   # rationale: Necessary for efficient file transfers.


### PR DESCRIPTION
Fixes the`lts/csm-1.5` build for `node-images`