### PR TITLE
OpenSCAP URL and OpenSSH Fix

### DIFF
--- a/roles/node_images_base/files/scripts/common/openscap.sh
+++ b/roles/node_images_base/files/scripts/common/openscap.sh
@@ -29,16 +29,16 @@ TEMP_DIR=$(mktemp -d)
 
 # Obtain the relevant OVAL files, download to a temporary directory.
 cd $TEMP_DIR
-curl --retry-connrefused --retry 25 -f -O -J https://ftp.suse.com/pub/projects/security/oval/suse.linux.enterprise.server.${SLES_MAJOR}.xml
-curl --retry-connrefused --retry 25 -f -O -J https://ftp.suse.com/pub/projects/security/oval/suse.linux.enterprise.server.${SLES_MAJOR}-patch.xml
+curl --retry-connrefused --retry 25 -f -O -J https://${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}@artifactory.algol60.net/artifactory/suse-pub-mirror/projects/security/oval/suse.linux.enterprise.server.${SLES_MAJOR}.xml
+curl --retry-connrefused --retry 25 -f -O -J https://${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}@artifactory.algol60.net/artifactory/suse-pub-mirror/projects/security/oval/suse.linux.enterprise.server.${SLES_MAJOR}-patch.xml
 
 # Create oval test results in /tmp so the Pipeline can find them in an expected location.
 echo 'Running OVAL test ...'
-oscap oval eval --results oval-results.xml suse.linux.enterprise.server.${SLES_MAJOR}.xml > oval-standard-out.txt
+oscap oval eval --skip-valid --results oval-results.xml suse.linux.enterprise.server.${SLES_MAJOR}.xml > oval-standard-out.txt
 oscap oval generate report --output oval-report.html oval-results.xml
 
 echo 'Running OVAL Patch test...'
-oscap oval eval --results oval-patch-results.xml suse.linux.enterprise.server.${SLES_MAJOR}-patch.xml > oval-patch-standard-out.txt
+oscap oval eval --skip-valid --results oval-patch-results.xml suse.linux.enterprise.server.${SLES_MAJOR}-patch.xml > oval-patch-standard-out.txt
 oscap oval generate report --output oval-patch-report.html oval-patch-results.xml
 
 # Make available for Packer to download.

--- a/roles/node_images_base/vars/packages/suse.yml
+++ b/roles/node_images_base/vars/packages/suse.yml
@@ -122,7 +122,7 @@ packages:
   # rationale: Necessary for link layer discovery protocol (LLDP) during early startup.
   - open-lldp=1.1+44.0f781b4162d3-3.3.1
   # rationale: Necessary for incoming and outgoing secure shells.
-  - openssh=8.4p1-150300.3.18.2
+  - openssh=8.4p1-150300.3.22.1
   # rationale: Necessary for viewing, dumping, and inspecting PCI devices.
   - pciutils=3.5.6-150300.13.3.1
   # rationale: Necessary for efficient file transfers.


### PR DESCRIPTION
Updates the URL for OpenSCAP files to artifactory:
[MTL-2212](https://jira-pro.it.hpe.com:8443/browse/MTL-2212)

Bumps the OpenSSH version to fix the build:
[MTL-2211](https://jira-pro.it.hpe.com:8443/browse/MTL-2211)