### PR TITLE
MTL-2211 Repin remaining openssh packages

### DIFF
--- a/roles/node_images_base/vars/packages/suse.yml
+++ b/roles/node_images_base/vars/packages/suse.yml
@@ -121,6 +121,12 @@ packages:
   - openscap=1.3.6-150400.11.3.1
   # rationale: Necessary for link layer discovery protocol (LLDP) during early startup.
   - open-lldp=1.1+44.0f781b4162d3-3.3.1
+  # rationale: Dependency of openssh, pinned to prevent Zypper conflicts with pre-existing openssh-clients.
+  - openssh-clients=8.4p1-150300.3.22.1
+  # rationale: Dependency of openssh, pinned to prevent Zypper conflicts with pre-existing openssh-common.
+  - openssh-common=8.4p1-150300.3.22.1
+  # rationale: Dependency of openssh, pinned to prevent Zypper conflicts with pre-existing openssh-server.
+  - openssh-server=8.4p1-150300.3.22.1
   # rationale: Necessary for incoming and outgoing secure shells.
   - openssh=8.4p1-150300.3.22.1
   # rationale: Necessary for viewing, dumping, and inspecting PCI devices.


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Relates to: MTL-2211 #240 #243 

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->
The extra openssh packages were removed in https://github.com/Cray-HPE/metal-provision/pull/240/files#r1250894013 but these actually need to stay to mitigate pipeline failures when a new base image is built. New base images may have newer openssh dependencies installed, and Zypper will only bypass the prompt for downgrading them if every dependency is listed in the `zypper in` command.

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I have tested this by building an image using this branch HEAD, or this is does not pertain to the node-images pipeline.
- [ ] I tested this on internal system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
- [ ] I tested this on a vshasta system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
