### PR TITLE
CASMHMS-6057 No reds CT in vShasta hpe-csm-scripts update

### DIFF
--- a/roles/node_images_ncn_common/vars/packages/suse.yml
+++ b/roles/node_images_ncn_common/vars/packages/suse.yml
@@ -79,7 +79,7 @@ packages:
   - cray-kubectl-kubelogin-plugin=1.25.2-1
   - goss-servers=1.16.47-1
   - hpe-csm-goss-package=0.3.21-hpe3
-  - hpe-csm-scripts=0.6.0-1
+  - hpe-csm-scripts=0.6.1-1
   - loftsman=1.2.0-3
   - manifestgen=1.3.9-1
   # CM cli

--- a/roles/node_images_ncn_common/vars/packages/suse.yml
+++ b/roles/node_images_ncn_common/vars/packages/suse.yml
@@ -79,7 +79,7 @@ packages:
   - cray-kubectl-kubelogin-plugin=1.25.2-1
   - goss-servers=1.16.47-1
   - hpe-csm-goss-package=0.3.21-hpe3
-  - hpe-csm-scripts=0.6.1-1
+  - hpe-csm-scripts=0.5.6-1
   - loftsman=1.2.0-3
   - manifestgen=1.3.9-1
   # CM cli


### PR DESCRIPTION
### Summary and Scope

- Fixes: [CASMHMS-6057](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6057)

#### Issue Type

- Bugfix Pull Request

The HMS REDS service is not needed and therefore does not run in vShasta. This change skips the REDS CT when we are executing in vShasta.

### Prerequisites

- [X] I have included documentation in my PR (or it is not required)
- [X] I have tested this by building an image using this branch HEAD, or this is does not pertain to the node-images pipeline.
- [X] I tested this on internal system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
- [X] I tested this on a vshasta system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
 
### Idempotency

Executed the script to show that the REDS CT ran. Touched the /etc/google_system file and re-ran showing that the REDS CT was skipped. Removed /etc/google_system file and the REDS CT again executed.
 
### Risks and Mitigations
 
No known risks