### PR TITLE
Revert "CASMINST-6578 cani add this rpm to the release (#330)"

### DIFF
--- a/roles/node_images_management_vm/vars/packages/suse.yml
+++ b/roles/node_images_management_vm/vars/packages/suse.yml
@@ -23,7 +23,6 @@
 #
 ---
 packages:
-  - cani=0.1.0-1
   - canu=1.7.4-1
   - ceph-common<17.2.6
   - cloud-init-config-suse=23.1-150100.8.63.5

--- a/roles/node_images_pre_install_toolkit/vars/packages/suse.yml
+++ b/roles/node_images_pre_install_toolkit/vars/packages/suse.yml
@@ -28,7 +28,6 @@ packages:
   - dnsmasq=2.86-150400.14.3
   - wol=0.7.1-2.5
   # CSM
-  - cani=0.1.0-1
   - canu=1.7.4-1
   - cray-site-init=1.32.0-1
   - ilorest=4.2.0.0-20


### PR DESCRIPTION
This reverts commit 18b6c381076533f8cce3bd81017571f9428ee5d1.

Installing via cloud-init instead.