### PR TITLE
add dracut-mkinitrd-deprecated -- 1.5

### DIFF
--- a/roles/node_images_base/vars/packages/suse.yml
+++ b/roles/node_images_base/vars/packages/suse.yml
@@ -28,6 +28,8 @@ packages:
   #
   # rationale: Necessary for network time protocol (NTP).
   - chrony=4.1-150400.19.4
+  # rationale: provides /sbin/mkinitrd
+  - dracut-mkinitrd-deprecated=055+suse.366.g14047665-150500.3.6.1
   # rationale: Necessary for viewing and managing routing tables.
   - iproute2=5.14-150400.1.8
   # rationale: Dependency for daemon necessities.


### PR DESCRIPTION
### Summary and Scope

add package:
-  dracut-mkinitrd-deprecated

 dracut-mkinitrd-deprecated provides /sbin/mkinitrd which is required. I'll open a jira ticket to re-visit this and update code that depends on mkinitrd.

#### Issue Type

- Bugfix Pull Request

### Prerequisites

- [x] I have included documentation in my PR (or it is not required)
- [x] I have tested this by building an image using this branch HEAD, or this is does not pertain to the node-images pipeline.
- [x] I tested this on internal system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
- [x] I tested this on a vshasta system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
 