### PR TITLE
CASMINST-3431 Remove csm-rpms SP3

### DIFF
--- a/roles/node_images_management_vm/vars/packages/suse.yml
+++ b/roles/node_images_management_vm/vars/packages/suse.yml
@@ -23,7 +23,7 @@
 #
 ---
 packages:
-  - canu=1.7.4-1
+  - canu=1.7.5-1
   - cray-site-init=1.32.0-1
   - ilorest=4.2.0.0-20
   - metal-init=1.4.2-1

--- a/roles/node_images_ncn_common/vars/packages/suse.yml
+++ b/roles/node_images_ncn_common/vars/packages/suse.yml
@@ -29,7 +29,7 @@ packages:
   - ceph-common<17.2.7
   - conman=0.3.1-150500.1.2
   - cpupower=5.14-150500.9.3.1
-  - dracut-metal-mdsquash=2.4.2-1
+  - dracut-metal-mdsquash=2.4.3-1
   - emacs=27.2-150400.3.6.1
   - gperftools=2.5-4.12
   - gptfdisk=1.0.8-150400.1.7
@@ -75,13 +75,13 @@ packages:
   - cloud-init-config-suse=21.4-1
   - cloud-init-doc=21.4-1
   - cloud-init=21.4-1
-  - cray-kubectl-hns-plugin=1.0.1-1
-  - cray-kubectl-kubelogin-plugin=1.25.2-1
-  - goss-servers=1.16.47-1
+  - cray-kubectl-hns-plugin=1.0.2-1
+  - cray-kubectl-kubelogin-plugin=1.25.3-1
+  - goss-servers=1.17.4-1
   - hpe-csm-goss-package=0.3.21-hpe3
-  - hpe-csm-scripts=0.6.1-1
+  - hpe-csm-scripts=0.6.2-1
   - loftsman=1.2.0-3
-  - manifestgen=1.3.9-1
+  - manifestgen=1.3.10-1
   # CM cli
   - cm-cli=1.5.0-1
   # CVT

--- a/roles/node_images_ncn_kubernetes/vars/packages/suse.yml
+++ b/roles/node_images_ncn_kubernetes/vars/packages/suse.yml
@@ -32,8 +32,8 @@ packages:
   # for proper vshasta-v2 functionality.
   - platform-utils=1.6.3-1
   # Metal
-  - dracut-metal-dmk8s=2.1.0-1
-  - dracut-metal-luksetcd=2.1.0-1
+  - dracut-metal-dmk8s=2.1.1-1
+  - dracut-metal-luksetcd=2.1.1-1
   # DVS
   - insserv-compat=0.1-4.6.1
   # SAT

--- a/roles/node_images_pre_install_toolkit/vars/packages/suse.yml
+++ b/roles/node_images_pre_install_toolkit/vars/packages/suse.yml
@@ -28,7 +28,7 @@ packages:
   - dnsmasq=2.86-150400.14.3
   - wol=0.7.1-2.5
   # CSM
-  - canu=1.7.4-1
+  - canu=1.7.5-1
   - cray-site-init=1.32.0-1
   - ilorest=4.2.0.0-20
   - metal-basecamp=1.2.6-1

--- a/roles/packages_csm/vars/packages/suse.yml
+++ b/roles/packages_csm/vars/packages/suse.yml
@@ -24,10 +24,10 @@
 ---
 packages:
   # Python
-  - craycli=0.82.8-1
+  - craycli=0.82.9-1
   - csm-auth-utils=1.0.0-1
   - csm-node-heartbeat=2.1-3
-  - csm-node-identity=1.0.20-1
+  - csm-node-identity=1.0.22-1
   - python3-Jinja2=2.10.1-3.10.2
   - python3-MarkupSafe=1.0-1.29
   - python3-PyYAML=5.4.1-1.1

--- a/scripts/repos/cray.template.repos
+++ b/scripts/repos/cray.template.repos
@@ -1,7 +1,6 @@
 # CSM / CLOUD / PET / MTL / NET
 https://${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}@artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos?auth=basic                                                                                                cray-algol60-csm-rpms-stable-noos                                                          --no-gpgcheck -p 87
 https://${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}@artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-${releasever_major}sp${releasever_minor}?auth=basic                                                        cray-algol60-csm-rpms-stable-sle-${releasever_major}sp${releasever_minor}                  --no-gpgcheck -p 88
-https://${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}@artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3?auth=basic                                                                                           cray-algol60-csm-rpms-stable-sle-15sp3                                                     --no-gpgcheck -p 89
 
 # SAT
 https://${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}@artifactory.algol60.net/artifactory/sat-rpms/hpe/stable/sle-15sp3?auth=basic                                                                                           cray-algol60-sat-rpms-stable-sle-15sp3                                                     --no-gpgcheck -p 88


### PR DESCRIPTION
Removes the csm-rpms sle-15sp3 repository, and updates pins to fetch noos editions of RPMs previously pulled from that repository.

https://jira-pro.it.hpe.com:8443/browse/CASMINST-3431

- https://github.com/Cray-HPE/prodmgr/pull/20
- https://github.com/Cray-HPE/canu/pull/431
- https://github.com/Cray-HPE/craycli/pull/128
- https://github.com/Cray-HPE/manifestgen/pull/34
- https://github.com/Cray-HPE/hpe-csm-scripts/pull/58
- https://github.com/Cray-HPE/hpe-csm-scripts/pull/56
- https://github.com/Cray-HPE/hpe-csm-scripts/pull/57
- https://github.com/Cray-HPE/dracut-metal-dmk8s/pull/35
- https://github.com/Cray-HPE/dracut-metal-mdsquash/pull/60
- https://github.com/Cray-HPE/dracut-metal-luksetcd/pull/44
- https://github.com/Cray-HPE/cray-kubectl-hns-plugin/pull/3
- https://github.com/Cray-HPE/cray-kubectl-kubelogin-plugin/pull/3
- https://github.com/Cray-HPE/metal-ipmitool/pull/4 (no version change)
- https://github.com/Cray-HPE/csm-testing/pull/522
- https://github.com/Cray-HPE/csm-testing/pull/524
- https://github.com/Cray-HPE/csm-testing/pull/523
- https://github.com/Cray-HPE/csm-node-identity/pull/14
- cloud-init RPMs were copied from sle-15sp3 to noos without a version change


