### PR TITLE
Fix isolated network for hypervisor and management VM

### DIFF
--- a/roles/node_images_hypervisor/files/management-vm/domain.xml
+++ b/roles/node_images_hypervisor/files/management-vm/domain.xml
@@ -74,7 +74,7 @@
       <target type='virtio' name='org.qemu.guest_agent.0'/>
     </channel>
     <!-- Start off with the default, isolated network. -->
-    <interface type="network">
+    <interface type='network'>
       <source network='isolated'/>
       <model type='virtio'/>
     </interface>

--- a/roles/node_images_hypervisor/files/management-vm/domain.xml
+++ b/roles/node_images_hypervisor/files/management-vm/domain.xml
@@ -69,14 +69,14 @@
       <source file='/vms/cloud-init/management-vm/cloud-init.iso'/>
       <target dev='hda' bus='ide'/>
     </disk>
-    <!-- Start off with the default, isolated network. -->
-    <interface>
-      <source network='isolated'/>
-      <model type='virtio'/>
-    </interface>
     <channel type='unix'>
       <source mode='bind'/>
       <target type='virtio' name='org.qemu.guest_agent.0'/>
     </channel>
+    <!-- Start off with the default, isolated network. -->
+    <interface type="network">
+      <source network='isolated'/>
+      <model type='virtio'/>
+    </interface>
   </devices>
 </domain>

--- a/roles/node_images_hypervisor/files/management-vm/isolated.xml
+++ b/roles/node_images_hypervisor/files/management-vm/isolated.xml
@@ -1,4 +1,34 @@
+<!--
+  ~
+  ~ MIT License
+  ~
+  ~ (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+  ~
+  ~ Permission is hereby granted, free of charge, to any person obtaining a
+  ~ copy of this software and associated documentation files (the "Software"),
+  ~ to deal in the Software without restriction, including without limitation
+  ~ the rights to use, copy, modify, merge, publish, distribute, sublicense,
+  ~ and/or sell copies of the Software, and to permit persons to whom the
+  ~ Software is furnished to do so, subject to the following conditions:
+  ~
+  ~ The above copyright notice and this permission notice shall be included
+  ~ in all copies or substantial portions of the Software.
+  ~
+  ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  ~ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+  ~ THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+  ~ OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+  ~ ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+  ~ OTHER DEALINGS IN THE SOFTWARE.
+  ~
+  -->
+
 <network>
   <name>isolated</name>
-  <ip address='169.254.0.1' netmask='255.255.255.252'/>
+  <ip family="ipv4" address="192.168.0.1" prefix="30">
+    <dhcp>
+      <range start="192.168.0.2" end="192.168.0.2"/>
+    </dhcp>
+  </ip>
 </network>

--- a/roles/node_images_hypervisor/files/management-vm/isolated.xml
+++ b/roles/node_images_hypervisor/files/management-vm/isolated.xml
@@ -26,9 +26,9 @@
 
 <network>
   <name>isolated</name>
-  <ip family="ipv4" address="192.168.0.1" prefix="30">
+  <ip family='ipv4' address='192.168.0.1' prefix='30'>
     <dhcp>
-      <range start="192.168.0.2" end="192.168.0.2"/>
+      <range start='192.168.0.2' end='192.168.0.2'/>
     </dhcp>
   </ip>
 </network>

--- a/roles/node_images_management_vm/files/cloud/cloud.cfg.d/00_network.cfg
+++ b/roles/node_images_management_vm/files/cloud/cloud.cfg.d/00_network.cfg
@@ -6,8 +6,6 @@ network:
       dhcp4: true
       dhcp6: false
       mtu: 1500
-      addresses:
-        - 169.254.0.2/30
     # eth1: metal interface, will receive a static IP.
     eth1:
       dhcp4: false

--- a/roles/node_images_management_vm/files/cloud/templates/hosts.suse.tmpl
+++ b/roles/node_images_management_vm/files/cloud/templates/hosts.suse.tmpl
@@ -30,4 +30,4 @@ ff02::1 ipv6-allnodes
 ff02::2 ipv6-allrouters
 ff02::3 ipv6-allhosts
 
-169.254.0.1 localhypervisor
+192.168.0.1 localhypervisor


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: Isolated network added in #345 and #342 

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->
1. `type="network"` was missing from the `<interface>` definition in `domain.xml`
2. wicked was rejecting DHCP leases on the link-local network, had to switch to something else (using Class C, private network)

Minor edits:
- Switched to `prefix` instead of `netmask` in `isolated.xml` because it's more human-readable.
- Updated `localhypervisor` entry in `/etc/hosts` for new IP range
- Reordered `<devices>` in `domain.xml` so the `<interface>` is on the bottom

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I have tested this by building an image using this branch HEAD, or this is does not pertain to the node-images pipeline.
- [x] I tested this on internal system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
- [ ] I tested this on a vshasta system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
