### PR TITLE
Task should be deleted

### DIFF
--- a/roles/node_images_application/tasks/main.yml
+++ b/roles/node_images_application/tasks/main.yml
@@ -31,12 +31,6 @@
     - never
     - packages
 
-- name: Copy cloud.cfg configuration
-  ansible.builtin.copy:
-    src: files/cloud.cfg
-    dest: /etc/cloud/cloud.cfg
-    mode: "644"
-
 # Perms shold be set a different way
 - name: Install cmdline-perm.service
   ansible.builtin.copy:


### PR DESCRIPTION
cloud-init config is handled by the `cloud_init` role, this task was supposed to go away but was neglected during that role's creation.
