### PR TITLE
add date to initrd

### DIFF
--- a/roles/node_images_base/files/metal/dracut.conf.d/00-metal.conf
+++ b/roles/node_images_base/files/metal/dracut.conf.d/00-metal.conf
@@ -44,7 +44,7 @@ hostonly_mode="sloppy"
 use_fstab="yes"
 
 # Install useful tools into the initrd for wiping disks and reading files.
-install_items+=" less lsblk rmdir sgdisk vgremove wipefs " # Needs to start and end with a space to mitigate warnings.
+install_items+=" date less lsblk rmdir sgdisk vgremove wipefs " # Needs to start and end with a space to mitigate warnings.
 
 # Ensure our mdadm.conf exists in the initrd to prevent hostnamed MDs.
 mdadmconf="yes"


### PR DESCRIPTION
### Summary and Scope

add `date` to our initrd. The cray-udev-network-cn rpm requires it.

- Fixes: Boot failure on stock sles compute images

#### Issue Type


- Bugfix Pull Request

### Prerequisites


- [x] I have included documentation in my PR (or it is not required)
- [x] I have tested this by building an image using this branch HEAD, or this is does not pertain to the node-images pipeline.
- [x] I tested this on internal system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
 
### Idempotency
 
Yes
 
### Risks and Mitigations
 
None