### PR TITLE
MTL-2253 `systemd` and `udev` PTF for Remote and USB ISO Boots

### DIFF
--- a/roles/node_images_base/files/scripts/metal/create-iso-artifact.sh
+++ b/roles/node_images_base/files/scripts/metal/create-iso-artifact.sh
@@ -100,14 +100,13 @@ function install-grub2 {
 
 function create-iso {
     local iso="${ISO_OUTPUT}/${ISO_NAME}.iso"
-    local joliet=on
     mkdir -pv "${ISO_OUTPUT}" || return 1
     xorriso \
         -publisher 'Cray-HPE' \
         -application_id ${app_id} \
         -preparer_id 'METAL - https://github.com/Cray-HPE/node-images' \
         -copyright_file /tmp/LICENSE \
-        -joliet "${joliet}" \
+        -joliet on \
         -padding 0 \
         -volid "${ISO_FSLABEL}" \
         -outdev ${iso} \
@@ -128,14 +127,6 @@ function create-iso {
         -boot_image any efi_path=--interval:appended_partition_2:all:: \
         -boot_image any platform_id=0xef \
         -boot_image any emul_type=no_emulation
-
-    # Remove the duplicate label observed between the ISO and the ISO partition (MTL-2191, MTL-2192, SUSE #00697765)
-    if [ "${joliet}" = 'on' ]; then
-        echo -n 'ISO' | iconv -f utf8 -t UCS-2BE | dd bs=1 seek=$((0x9028)) conv=notrunc of="${iso}"
-    else
-        echo -n "ISO" | dd bs=1 seek=$((0x8028)) of="${iso}"
-    fi
-
     # NOTE: Can't sign the ISO with the HPE key because it is too large. --create-signature could be used but this makes a unique key.
     tagmedia --md5 --check --pad 150 ${iso}
 }

--- a/roles/node_images_base/vars/packages/suse.yml
+++ b/roles/node_images_base/vars/packages/suse.yml
@@ -33,23 +33,23 @@ packages:
   # rationale: Necessary for viewing and managing routing tables.
   - iproute2=5.14-150400.1.8
   # rationale: Dependency for daemon necessities.
-  - libsystemd0=249.16-150400.8.28.3
+  - libsystemd0=249.16-150400.8.25.7
   # rationale: Dependency for daemon necessities.
-  - libudev1=249.16-150400.8.28.3
+  - libudev1=249.16-150400.8.25.7
   # rationale: Dependency for daemon necessities.
-  - systemd-coredump=249.16-150400.8.28.3
+  - systemd-coredump=249.16-150400.8.25.7
   # rationale: Dependency for daemon necessities.
-  - systemd-lang=249.16-150400.8.28.3
+  - systemd-lang=249.16-150400.8.25.7
   # rationale: Necessary for daemons.
-  - systemd-sysvinit=249.16-150400.8.28.3
+  - systemd-sysvinit=249.16-150400.8.25.7
   # rationale: Necessary for daemons.
-  - systemd=249.16-150400.8.28.3
+  - systemd=249.16-150400.8.25.7
   # rationale: Necessary for TPM2.
   - tpm2.0-abrmd=2.4.0-150400.1.6
   # rationale: Necessary for TPM2.
   - tpm2.0-tools=5.2-150400.4.6
   # rationale: Necessary for hardware interfaces.
-  - udev=249.16-150400.8.28.3
+  - udev=249.16-150400.8.25.7
   #
   ## Filesystems and block device helpers
   #

--- a/roles/node_images_base/vars/packages/suse.yml
+++ b/roles/node_images_base/vars/packages/suse.yml
@@ -33,23 +33,23 @@ packages:
   # rationale: Necessary for viewing and managing routing tables.
   - iproute2=5.14-150400.1.8
   # rationale: Dependency for daemon necessities.
-  - libsystemd0=249.16-150400.8.25.7
+  - libsystemd0=249.16-150400.8.28.3.26498.1.PTF.1213185
   # rationale: Dependency for daemon necessities.
-  - libudev1=249.16-150400.8.25.7
+  - libudev1=249.16-150400.8.28.3.26498.1.PTF.1213185
   # rationale: Dependency for daemon necessities.
-  - systemd-coredump=249.16-150400.8.25.7
+  - systemd-coredump=249.16-150400.8.28.3.26498.1.PTF.1213185
   # rationale: Dependency for daemon necessities.
-  - systemd-lang=249.16-150400.8.25.7
+  - systemd-lang=249.16-150400.8.28.3.26498.1.PTF.1213185
   # rationale: Necessary for daemons.
-  - systemd-sysvinit=249.16-150400.8.25.7
+  - systemd-sysvinit=249.16-150400.8.28.3.26498.1.PTF.1213185
   # rationale: Necessary for daemons.
-  - systemd=249.16-150400.8.25.7
+  - systemd=249.16-150400.8.28.3.26498.1.PTF.1213185
   # rationale: Necessary for TPM2.
   - tpm2.0-abrmd=2.4.0-150400.1.6
   # rationale: Necessary for TPM2.
   - tpm2.0-tools=5.2-150400.4.6
   # rationale: Necessary for hardware interfaces.
-  - udev=249.16-150400.8.25.7
+  - udev=249.16-150400.8.28.3.26498.1.PTF.1213185
   #
   ## Filesystems and block device helpers
   #

--- a/scripts/repos/suse.template.repos
+++ b/scripts/repos/suse.template.repos
@@ -80,8 +80,11 @@ https://${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}@artifactory.algol60.net/artifac
 # free range routing
 https://${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}@artifactory.algol60.net/artifactory/opensuse-mirror/network/${releasever_major}.${releasever_minor}/?auth=basic                                                          openSUSE-network-SLE                                    -g -p 90
 
-# SUSE PTF Packages
-#https://${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}@artifactory.algol60.net/artifactory/suse-external/PTF/${releasever_major}-SP${releasever_minor}/SLE-Module-Basesystem?auth=basic                                         SUSE-SLE-Module-Basesystem-PTF                          -g -p 90
+# SUSE PTF 1204911 Kernel
+#https://${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}@artifactory.algol60.net/artifactory/suse-external/PTF/1204911/${releasever_major}-SP${releasever_minor}?auth=basic                                                       SUSE-PTF.1204911-15-SP4                                 -g -p 90
+
+# SUSE PTF systemd/udev
+https://${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}@artifactory.algol60.net/artifactory/suse-external/PTF/1213185/SLE-Module-Basesystem?auth=basic                                                                           SUSE-PTF.1213185-SLE-Module-Basesystem                  -g -p 89
 
 # These storage repos are only offered in x86_64
 https://${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}@artifactory.algol60.net/artifactory/sles-mirror/Products/Storage/7/x86_64/product?auth=basic                                                                             SUSE-Storage-7-x86_64-Pool                              -g -p 89


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: MTL-2253
- Relates to: MTL-2192, CASMTRIAGE-5930 #298 

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->
This pulls in PTF packages for `systemd` and `udev` and rolls back the previous MTL-2192 workaround. The new PTF packages fix the USB ISO boot, and reverting the workaround fixes the RemoteISO boot.

I successfully built a Fawkes ISO and tested it via USB and iLO BMC.

I did not test a pre-install-toolkit ISO, I couldn't get one to build. However all of our ISOs are built the same way, and tests I did were sufficient to say all of our ISOs work.

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [x] I have tested this by building an image using this branch HEAD, or this is does not pertain to the node-images pipeline.
- [x] I tested this on internal system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
- [ ] I tested this on a vshasta system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
