### PR TITLE
MTL-2247-ssh-keys

### DIFF
--- a/roles/node_images_hypervisor/files/systemd/ssh-import-id.service
+++ b/roles/node_images_hypervisor/files/systemd/ssh-import-id.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=SSH Import ID
+Documentation=https://manpages.ubuntu.com/manpages/xenial/man1/ssh-import-id.1.html
+Requires=network-online.target
+After=network-online.target
+
+[Service]
+ExecCondition=/bin/bash -c '[ ! -f /etc/ssh/ssh_import_id.disabled ]'
+Environment=URL=http://management-vm:3000/api/v1/repos/root/ssh-public-keys/raw/ssh-public-keys.json
+Environment=KEYS_FILE=/root/.ssh/authorized_keys
+ExecStartPre=/bin/bash -c 'mkdir -p /root/.ssh'
+ExecStart=/bin/bash -c "curl -sX 'GET' ${URL} -H 'accept: application/json' | jq -r '.ssh_authorized_keys[]' > ${KEYS_FILE}"
+Restart=on-failure
+KillMode=control-group
+RemainAfterExit=true
+Type=oneshot
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/node_images_hypervisor/tasks/main.yml
+++ b/roles/node_images_hypervisor/tasks/main.yml
@@ -60,6 +60,12 @@
     src: management-vm/
     dest: /srv/cray/management-vm/
 
+- name: Copy systemd configuration
+  ansible.posix.synchronize:
+    delete: false
+    src: systemd/
+    dest: /usr/lib/systemd/system/
+
 # Enable if/when services are defined.
 # - name: Setup services
 #   ansible.builtin.include_tasks:

--- a/roles/node_images_hypervisor/vars/services/suse.yml
+++ b/roles/node_images_hypervisor/vars/services/suse.yml
@@ -23,3 +23,6 @@
 #
 ---
 services:
+  - enabled: true
+    name: ssh-import-id.service
+    state: stopped


### PR DESCRIPTION
### Summary and Scope

- add ssh-import-id systemd service to pull public ssh key from management-vm
- add ssh-import-id systemd service in build pipeline and enable it

#### Issue Type

- RFE Pull Request

### Prerequisites

- [x] I have included documentation in my PR (or it is not required)
- [x] I have tested this by building an image using this branch HEAD, or this is does not pertain to the node-images pipeline.
- [x] I tested this on internal system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
 
### Idempotency
 
Yes
 
### Risks and Mitigations

None known