### PR TITLE
CASMTRIAGE-5941: remove character special files from filesystem 

### DIFF
--- a/roles/node_images_base/files/scripts/metal/create-kis-artifacts.sh
+++ b/roles/node_images_base/files/scripts/metal/create-kis-artifacts.sh
@@ -30,8 +30,9 @@ function cleanup {
     rm -rf /mnt/squashfs
 }
 
+# shellcheck disable=SC1091
 # Source common dracut parameters.
-. "$(dirname $0)/../common/dracut-lib.sh"
+. "$(dirname "$0")/../common/dracut-lib.sh"
 
 # This facilitates creating the artifacts in the NCN pipeline.
 mkdir -pv /mnt/squashfs /squashfs
@@ -39,7 +40,7 @@ mount -v -o bind / /mnt/squashfs
 
 if [[ "$1" != "squashfs-only" ]]; then
     echo "Creating initrd/kernel artifacts"
-    
+
     # NOTE: These mounts help create metal artifacts when running inside of the NCN pipeline, they are not necessary when this script runs
     #       on a physical server. These are harmless enough that they're always mounted, regardless of context.
     if [ "$(stat -c %d:%i / >/dev/null 2>&1)" != "$(stat -c %d:%i /proc/1/root/. 2>&1 >/dev/null)" ]; then
@@ -52,10 +53,10 @@ if [[ "$1" != "squashfs-only" ]]; then
         mount --bind /sys /mnt/squashfs/sys
         mount --bind /var /mnt/squashfs/var
     fi
-    
-    # This has been here since we first made images, more or less as a last/final check that we have no cache left-over from the auto-install.  
+
+    # This has been here since we first made images, more or less as a last/final check that we have no cache left-over from the auto-install.
     [ -f /var/adm/autoinstall/cache ] && rm -rf /var/adm/autoinstall/cache
-    
+
     unshare -R /mnt/squashfs bash -c "dracut \
         --add \"$(printf '%s' "${ADD[*]}")\" \
         --force \
@@ -69,7 +70,7 @@ if [[ "$1" != "squashfs-only" ]]; then
         ARCH_KERNEL="Image-${KVER}" || \
         ARCH_KERNEL="vmlinuz-${KVER}"
 
-    cp -v /mnt/squashfs/boot/${ARCH_KERNEL} /squashfs/${KVER}.kernel
+    cp -v /mnt/squashfs/boot/"${ARCH_KERNEL}" /squashfs/"${KVER}".kernel
 
     cp -v /mnt/squashfs/tmp/initrd.img.xz /squashfs/initrd.img.xz
     rm -f /mnt/squashfs/tmp/initrd.img.xz

--- a/roles/node_images_base/files/scripts/metal/create-kis-artifacts.sh
+++ b/roles/node_images_base/files/scripts/metal/create-kis-artifacts.sh
@@ -85,6 +85,8 @@ if [[ "$1" != "squashfs-only" ]]; then
 fi
 
 if [[ "$1" != "kernel-initrd-only" ]]; then
+  echo "Removing character special files from the filesystem"
+  find /mnt/squashfs -type c -exec rm -f '{}' \;
   echo "Creating squashfs artifact"
   mksquashfs /mnt/squashfs \
       /squashfs/filesystem.squashfs \


### PR DESCRIPTION
### Summary and Scope

Remove character special files from the filesystem prior to creating the squashfs artifact.
<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: CASMTRIAGE-5941

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [x] I have included documentation in my PR (or it is not required)
- [x] I have tested this by building an image using this branch HEAD, or this is does not pertain to the node-images pipeline.
- [x] I tested this on internal system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
- [x] I tested this on a vshasta system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
