### PR TITLE
MTL-2254 Upgrade to nexus 3.38.0-1

### DIFF
--- a/roles/node_images_management_vm/vars/packages/suse.yml
+++ b/roles/node_images_management_vm/vars/packages/suse.yml
@@ -28,6 +28,6 @@ packages:
   - ilorest=4.2.0.0-20
   - metal-init=1.4.4-1
   - metal-ipxe=2.4.4-1
-  - metal-nexus=1.2.3-1
+  - metal-nexus=1.3.0-3.38.0_1
   - metal-observability=1.0.9-1
 patterns:

--- a/roles/node_images_pre_install_toolkit/vars/packages/suse.yml
+++ b/roles/node_images_pre_install_toolkit/vars/packages/suse.yml
@@ -34,6 +34,6 @@ packages:
   - metal-basecamp=1.2.6-1
   - metal-ipxe=2.4.4-1
   - metal-init=1.4.4-1
-  - metal-nexus=1.2.3-1
+  - metal-nexus=1.3.0-3.38.0_1
   - metal-observability=1.0.9-1
 patterns:


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: MTL-2254

#### Issue Type

<!--- Delete un-needed bullets -->

- RFE Pull Request

<!--- words; describe what this change is and what it is for. -->
Includes the new nexus 3.38.0-1 image, matching cray-nexus.

Also includes cray-nexus' current cray-setup-nexus image (0.10.1).

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I have tested this by building an image using this branch HEAD, or this is does not pertain to the node-images pipeline.
- [ ] I tested this on internal system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
- [ ] I tested this on a vshasta system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
