### PR TITLE
CASMHMS-6089 Update node heartbeat to use same gateway for vShasta and metal

### DIFF
--- a/group_vars/application/packages.suse.yml
+++ b/group_vars/application/packages.suse.yml
@@ -24,7 +24,7 @@
 ---
 packages:
   - csm-auth-utils=1.0.0-1
-  - csm-node-heartbeat=2.1-3
+  - csm-node-heartbeat=2.2-3
   # CMS Team
   - bos-reporter=2.6.3-1
   - cfs-debugger=1.5.0-1

--- a/group_vars/compute/packages.suse.yml
+++ b/group_vars/compute/packages.suse.yml
@@ -27,7 +27,7 @@ packages:
   # CSM Team
   - acpid=2.0.31-2.1
   - csm-auth-utils=1.0.0-1
-  - csm-node-heartbeat=2.1-3
+  - csm-node-heartbeat=2.2-3
   # CMS Team
   - bos-reporter=2.6.3-1
   - cfs-debugger=1.5.0-1


### PR DESCRIPTION
### Summary and Scope

Worker nodes on lemondrop were starting the cray-heartbeat with the wrong gateway address due to some virtio kernel modules that were loaded for qemu ARM builds. vShasta v2 uses the same gateway address that metal nodes do, so there is no need to differentiate between the two.

- Fixes:  [CASMHMS-6089](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6089)
- Requires:
- Relates to:

#### Issue Type

- Bugfix Pull Request

Fix for vShasta v2 API gateway.

### Prerequisites

- [X] I have included documentation in my PR (or it is not required)
- [X] I have tested this by building an image using this branch HEAD, or this is does not pertain to the node-images pipeline.
- [X] I tested this on internal system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
- [X] I tested this on a vshasta system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
 
### Idempotency
 
On systems that do not have any virtio kernel modules loaded the default path through the script is unchanged.
 
### Risks and Mitigations

No risks to metal installs.
