### PR TITLE
Use `+%Y-%m-%d_%H:%M:%S` for the release file

### DIFF
--- a/scripts/packer/cleanup-functions.sh
+++ b/scripts/packer/cleanup-functions.sh
@@ -266,7 +266,7 @@ function create_release_file {
       hash="$(echo "$artifact_version" | awk -F- '{print $1}')"
       epoch="$(echo "$artifact_version" | awk -F- '{print $NF}')"
     fi
-    timestamp="$(date -d "@${epoch:0:-3}" '+%Y:%m:%d-%H:%M:%S')"
+    timestamp="$(date -d "@${epoch:0:-3}" '+%Y-%m-%d_%H:%M:%S')"
     cat << EOF > "/etc/${name}-release"
 VERSION=$hash-$epoch
 TIMESTAMP=$timestamp


### PR DESCRIPTION
The release file from #375 created a human friendly date stamp with the format of:
```
2023:08:28-13:30:24
```

I'd prefer not overusing the same delimiter, it's my belief that it's easier to understand the date string with:
```
2023-08-28_13:30:31
```