### PR TITLE
WIP Add DHCLIENT_SET_HOSTNAME to compute role

### DIFF
--- a/roles/node_images_compute/tasks/main.yml
+++ b/roles/node_images_compute/tasks/main.yml
@@ -53,3 +53,10 @@
     path: /etc/fstab
     state: absent
     regexp: '^LABEL=ROOTRAID.*'
+
+- name: Configure dhcp settings
+  ansible.builtin.lineinfile:
+    path: /etc/sysconfig/network/dhcp
+    regexp: "{{ item.regexp }}"
+    line: "{{ item.line }}"
+  loop: "{{ dhcp }}"


### PR DESCRIPTION
### Summary and Scope

Allow compute nodes to set hostnames by setting `DHCLIENT_SET_HOSTNAME="yes"`.

This will allow the Application nodes to boot with the "compute" image and we can likely remove the separate build for "application" images. Instead, the compute image will be used and renamed as the application image.

Using this image on an application node without this change results in:
```
# ssh uan01 hostname
Warning: Permanently added 'uan01,10.252.1.14' (ECDSA) to the list of known hosts.
Password:
compute
```

### Prerequisites

- [x] I have included documentation in my PR (or it is not required)
- [ ] I have tested this by building an image using this branch HEAD, or this is does not pertain to the node-images pipeline.
- [ ] I tested this on internal system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
- [x] I tested this on a vshasta system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
 
### Idempotency
 
Yes
 
### Risks and Mitigations
 
Low risk
