### PR TITLE
CASMTRIAGE-5988 pre-install-toolkit bad FSLabel

### DIFF
--- a/roles/node_images_metal/files/scripts/metal/.gitignore
+++ b/roles/node_images_metal/files/scripts/metal/.gitignore
@@ -1,0 +1,1 @@
+grub.cfg

--- a/roles/node_images_metal/files/scripts/metal/create-iso-artifact.sh
+++ b/roles/node_images_metal/files/scripts/metal/create-iso-artifact.sh
@@ -50,7 +50,7 @@ fi
 
 echo "Building for [${ARCH}] [${EFI_BINARY}]"
 
-ISO_FSLABEL="${ISO_FSLABEL:-'CRAYLIVE'}"
+ISO_FSLABEL="${ISO_FSLABEL:-CRAYLIVE}"
 ISO_NAME="${ISO_NAME:-'ISO'}"
 ISO_OUTPUT='/tmp/iso'
 ISO_SOURCE="${ISO_OUTPUT}_src"

--- a/roles/node_images_metal/files/scripts/metal/create-iso-artifact.sh
+++ b/roles/node_images_metal/files/scripts/metal/create-iso-artifact.sh
@@ -51,6 +51,7 @@ fi
 echo "Building for [${ARCH}] [${EFI_BINARY}]"
 
 ISO_FSLABEL="${ISO_FSLABEL:-CRAYLIVE}"
+export ISO_FSLABEL
 ISO_NAME="${ISO_NAME:-'ISO'}"
 ISO_OUTPUT='/tmp/iso'
 ISO_SOURCE="${ISO_OUTPUT}_src"


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: CASMTRIAGE-5988
- Relates to: #375 

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->
This fixes the `grub.cfg` file for the pre-install-toolkit.

- The `ISO_FSLABEL`'s default value, that the pre-install-toolkit relies on, had single-quotes added to it. This creates a malformed label: `LABEL='CRAYLIVE'`
    ```bash
    ls -l /dev/disk/by-label/
    total 0
    lrwxrwxrwx 1 root root 10 Sep  1 15:35  BOOT -> ../../sdd2
    lrwxrwxrwx 1 root root 11 Sep  1 15:35  BOOTRAID -> ../../md124
    lrwxrwxrwx 1 root root 10 Sep  1 15:35  CRAYS3CACHE -> ../../dm-0
    lrwxrwxrwx 1 root root  9 Sep  1 15:35  ETCDLVM -> ../../sdc
    lrwxrwxrwx 1 root root 10 Sep  1 15:35  PITDATA -> ../../sdd4
    lrwxrwxrwx 1 root root 11 Sep  1 15:35  ROOTRAID -> ../../md126
    lrwxrwxrwx 1 root root 11 Sep  1 15:35  SQFSRAID -> ../../md125
    lrwxrwxrwx 1 root root 10 Sep  1 15:35 '\x27CRAYLIVE\x27' -> ../../sdd1
    lrwxrwxrwx 1 root root 10 Sep  1 15:35  cow -> ../../sdd3
    ```
- The `ISO_FSLABEL` was not being exported in the script, it was being exported only when a Packer provisioner or a user defined and exported it themselves. This was causing a blank label to be set for Packer builds that relied on the default value (pre-install-toolkit): `root=live:LABEL=` instead of `root=live:LABEL=$ISO_FSLABEL`

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I have tested this by building an image using this branch HEAD, or this is does not pertain to the node-images pipeline.
- [ ] I tested this on internal system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
- [ ] I tested this on a vshasta system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
