### PR TITLE
Do not preserve `.j2` suffix

### DIFF
--- a/pb_node_images_management-vm.yml
+++ b/pb_node_images_management-vm.yml
@@ -25,6 +25,8 @@
 - name: Node Images Management VM
   hosts: management_vm
   become: true # Enable builds that do not login as root to escalate privilege.
+  environment:
+    HTTPS_PROXY: "{{ HTTPS_PROXY | default() }}"
   vars_files:
     - vars/fawkes.yml
   roles:

--- a/roles/node_images_management_vm/tasks/main.yml
+++ b/roles/node_images_management_vm/tasks/main.yml
@@ -32,7 +32,7 @@
   ansible.builtin.template:
     mode: '0644'
     src: cloud/templates/hosts.suse.tmpl.j2
-    dest: /etc/cloud/templates/hosts.suse.tmpl.j2
+    dest: /etc/cloud/templates/hosts.suse.tmpl
 
 - name: Configure DNS Forwarder
   ansible.builtin.lineinfile:

--- a/roles/node_images_management_vm/tasks/main.yml
+++ b/roles/node_images_management_vm/tasks/main.yml
@@ -22,12 +22,6 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 ---
-- name: Sync new cloud-init files
-  ansible.posix.synchronize:
-    delete: false
-    src: cloud/
-    dest: /etc/cloud/
-
 - name: Add hosts template
   ansible.builtin.template:
     mode: '0644'


### PR DESCRIPTION
When templating, the `.j2` suffix must be removed.
