### PR TITLE
Correct the nexus sub-path

### DIFF
--- a/group_vars/management_vm/packages.suse.yml
+++ b/group_vars/management_vm/packages.suse.yml
@@ -29,7 +29,7 @@ packages:
   - dnsmasq=2.86-150400.14.3
   - gru=0.0.2-1
   - metal-init=1.4.4-1
-  - metal-nexus=1.3.0-3.38.0_1
+  - metal-nexus=1.3.1-3.38.0_1
   - metal-observability=1.0.9-1
   - sqlite3=3.39.3-150000.3.20.1
   - terraform=0.13.4-6.3.1

--- a/group_vars/pre_install_toolkit/packages.suse.yml
+++ b/group_vars/pre_install_toolkit/packages.suse.yml
@@ -34,5 +34,5 @@ packages:
   - metal-basecamp=1.2.6-1
   - metal-ipxe=2.4.4-1
   - metal-init=1.4.4-1
-  - metal-nexus=1.3.0-3.38.0_1
+  - metal-nexus=1.3.1-3.38.0_1
   - metal-observability=1.0.9-1

--- a/roles/bootserver/templates/apache2/vhosts.d/vhosts.htaccess.j2
+++ b/roles/bootserver/templates/apache2/vhosts.d/vhosts.htaccess.j2
@@ -97,8 +97,8 @@
     # https://help.sonatype.com/repomanager3/planning-your-implementation/run-behind-a-reverse-proxy#RunBehindaReverseProxy-Apachehttpd.1
     RewriteRule "^/nexus$" "/nexus/" [R]
     <Location "/nexus/">
-        ProxyPass http://localhost:{{ port_nexus }}/
-        ProxyPassReverse http://localhost:{{ port_nexus }}/
+        ProxyPass http://localhost:{{ port_nexus }}/nexus/
+        ProxyPassReverse http://localhost:{{ port_nexus }}/nexus/
     </Location>
 </VirtualHost>
 
@@ -110,8 +110,8 @@
     ProxyTimeout 300
     ServerName packages
     ServerAlias packages
-    ProxyPass / http://localhost:{{ port_nexus }}/ nocanon
-    ProxyPassReverse / http://localhost:{{ port_nexus }}/
+    ProxyPass / http://localhost:{{ port_nexus }}/nexus/ nocanon
+    ProxyPassReverse / http://localhost:{{ port_nexus }}/nexus/
 </VirtualHost>
 
 # Necessary for http://packages.mtl to proxy to nexus.
@@ -122,6 +122,6 @@
     ProxyTimeout 300
     ServerName packages.mtl
     ServerAlias packages.mtl
-    ProxyPass / http://localhost:{{ port_nexus }}/ nocanon
-    ProxyPassReverse / http://localhost:{{ port_nexus }}/
+    ProxyPass / http://localhost:{{ port_nexus }}/nexus/ nocanon
+    ProxyPassReverse / http://localhost:{{ port_nexus }}/nexus/
 </VirtualHost>

--- a/roles/node_images_pre_install_toolkit/files/apache2/nexus.conf
+++ b/roles/node_images_pre_install_toolkit/files/apache2/nexus.conf
@@ -11,8 +11,8 @@
   ProxyTimeout 300
   ServerName packages
   ServerAlias packages
-  ProxyPass / http://localhost:8081/ nocanon
-  ProxyPassReverse / http://localhost:8081/
+  ProxyPass / http://localhost:8081/nexus/ nocanon
+  ProxyPassReverse / http://localhost:8081/nexus/
 </VirtualHost>
 
 # Necessary for packages.nmn to proxy to nexus.
@@ -23,6 +23,6 @@
   ProxyTimeout 300
   ServerName packages.nmn
   ServerAlias packages.nmn
-  ProxyPass / http://localhost:8081/ nocanon
-  ProxyPassReverse / http://localhost:8081/
+  ProxyPass / http://localhost:8081/nexus/ nocanon
+  ProxyPassReverse / http://localhost:8081/nexus/
 </VirtualHost>


### PR DESCRIPTION
Nexus itself is being reconfigured to operate with a sub-path, all proxies must also redirect to the new sub-path running at localhost:8081/nexus.

For more context, see: https://github.com/Cray-HPE/metal-nexus/pull/23