### PR TITLE
Update `ssh-import-id.service`

### DIFF
--- a/roles/node_images_hypervisor/templates/systemd/ssh-import-id.service.j2
+++ b/roles/node_images_hypervisor/templates/systemd/ssh-import-id.service.j2
@@ -8,8 +8,8 @@ After=network-online.target
 ExecCondition=/bin/bash -c '[ ! -f /etc/ssh/ssh_import_id.disabled ]'
 Environment=URL=http://{{ server_name }}/git/api/v1/repos/root/ssh-public-keys/raw/ssh-public-keys.json
 Environment=KEYS_FILE=/root/.ssh/authorized_keys
-ExecStartPre=/bin/bash -c 'mkdir -p /root/.ssh'
-ExecStart=/bin/bash -c "curl -sX 'GET' ${URL} -H 'accept: application/json' | jq -r '.ssh_authorized_keys[]' > ${KEYS_FILE}"
+ExecStartPre=/bin/bash -c 'install -d -m 700 /root/.ssh'
+ExecStart=/bin/bash -c "set -o pipefail; curl -f -sX 'GET' ${URL} -H 'accept: application/json' | jq -r '.ssh_authorized_keys[]' > ${KEYS_FILE}"
 Restart=on-failure
 KillMode=control-group
 RemainAfterExit=true


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->
- Set permissions when creating `/root/.ssh`, if this folder really does not exist then `umask` would've created it with `755` instead of `700`.
- Ensure `curl` returns a non-zero on failure to prevent false positives, since `curl` is piped we also need to set `pipefail`.
With `gitea.service` stopped on the management-vm, restarting `ssh-import-id.service` returns code `22` from `curl`.

```bash
hypervisor:~ # systemctl status ssh-import-id
× ssh-import-id.service - SSH Import ID
     Loaded: loaded (/usr/lib/systemd/system/ssh-import-id.service; enabled; vendor preset: disabled)
     Active: failed (Result: exit-code) since Wed 2023-09-06 16:55:54 UTC; 941ms ago
       Docs: https://manpages.ubuntu.com/manpages/xenial/man1/ssh-import-id.1.html
    Process: 4814 ExecCondition=/bin/bash -c [ ! -f /etc/ssh/ssh_import_id.disabled ] (code=exited, status=0/SUCCESS)
    Process: 4815 ExecStartPre=/bin/bash -c mkdir -p /root/.ssh (code=exited, status=0/SUCCESS)
    Process: 4816 ExecStart=/bin/bash -c set -o pipefail; curl -f -sX 'GET' ${URL} -H 'accept: application/json' | jq -r '.ssh_authorized_keys[]' > ${KEYS_FILE} (code=exi>
   Main PID: 4816 (code=exited, status=22)

Sep 06 16:55:54 hypervisor systemd[1]: ssh-import-id.service: Scheduled restart job, restart counter is at 5.
```

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I have tested this by building an image using this branch HEAD, or this is does not pertain to the node-images pipeline.
- [ ] I tested this on internal system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
- [ ] I tested this on a vshasta system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
