### PR TITLE
MTL-2256: include ucode-amd

### DIFF
--- a/vars/packages/suse.x86_64.yml
+++ b/vars/packages/suse.x86_64.yml
@@ -45,3 +45,6 @@ packages_x86_64:
   # rationale: Necessary for inspecting, configuring, and upgrading Mellanox devices.
   # mft: DO NOT INSTALL MFT FROM THE SPP REPO, NEVER APPEND "slesXspY"
   - mft=4.24.0-72
+  # rationale: Provides a mechanism to release updates for security advisories and functional issues.
+  - ucode-amd=20230724-150500.3.6.1
+  - ucode-intel=20230808-150200.27.1


### PR DESCRIPTION
### Summary and Scope

ucode-intel is already included by default/dependency.


<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: MTL-2256
- Relates to: zenbleed

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [x] I have included documentation in my PR (or it is not required)
- [x] I have tested this by building an image using this branch HEAD, or this is does not pertain to the node-images pipeline.
- [x] I tested this on internal system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
- [x] I tested this on a vshasta system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
