### PR TITLE
MTL-2270 Need `rd.peerdns=1`

### DIFF
--- a/roles/grub/defaults/main.yml
+++ b/roles/grub/defaults/main.yml
@@ -38,7 +38,8 @@ kernel_params:
   - rd.md.conf=0
   - rd.md=0
   - rd.neednet=1
+  - rd.peerdns=1
   - rd.shell
-  - "root=live:{{ iso_url }}"
+  - root=live:{{ iso_url }}
   - split_lock_detect=off
   - transparent_hugepage=never


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: MTL-2270

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->
For safe measure, set `rd.peerdns=1`. `1` is the default value, but because our fawkes images use NetworkManager we must always set this to `1` or auto DNS will not work.


This also removes some quotes and re-alpha-sorts the list of kernel parameters, the removal of the quotes was confirmed to work:

```bash
(metal-provision) [530]rusty@C02F43JEMD6P:~/gitstuffs/cray-shasta/metal-provision> ansible localhost -e @vars/fawkes.yml -e @roles/grub/defaults/main.yml -e ansible_architecture=x86_64 -m debug -a 'msg={{kernel_params}}'
[WARNING]: log file at /var/log/cray/ansible.log is not writeable and we cannot create it, aborting

[WARNING]: No inventory was parsed, only implicit localhost is available
localhost | SUCCESS => {
    "msg": [
        "root=live:http://bootserver/hypervisor-x86_64.iso",
        "biosdevname=1",
        "console=tty0",
        "console=ttyS0,115200",
        "crashkernel=360M",
        "iommu=pt",
        "ip=dhcp",
        "pcie_ports=native",
        "psi=1",
        "rd.live.ram=1",
        "rd.md.conf=0",
        "rd.md=0",
        "rd.neednet=1",
        "rd.peerdns=1",
        "rd.shell",
        "split_lock_detect=off",
        "transparent_hugepage=never"
    ]
}
```

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I have tested this by building an image using this branch HEAD, or this is does not pertain to the node-images pipeline.
- [ ] I tested this on internal system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
- [ ] I tested this on a vshasta system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
