### PR TITLE
use wget instead of curl

### DIFF
--- a/roles/node_images/files/scripts/common/openscap.sh
+++ b/roles/node_images/files/scripts/common/openscap.sh
@@ -37,16 +37,10 @@ TEMP_DIR=$(mktemp -d)
 
 # Obtain the relevant OVAL files, download to a temporary directory.
 cd $TEMP_DIR
-curl --retry-all-errors \
-     --retry 25 \
-     --retry-delay 5 \
-     -f -O -J \
+wget --continue --retry-connrefused --tries=25 --waitretry=5 \
      https://${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}@artifactory.algol60.net/artifactory/suse-pub-mirror/projects/security/oval/suse.linux.enterprise.server.${SLES_MAJOR}.xml
 
-curl --retry-all-errors \
-     --retry 25 \
-     --retry-delay 5 \
-     -f -O -J \
+wget --continue --retry-connrefused --tries=25 --waitretry=5 \
      https://${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}@artifactory.algol60.net/artifactory/suse-pub-mirror/projects/security/oval/suse.linux.enterprise.server.${SLES_MAJOR}-patch.xml
 
 # Create oval test results in /tmp so the Pipeline can find them in an expected location.


### PR DESCRIPTION
### Summary and Scope

Our DST ARM runners don't have a new enough version of curl so we can't use **--retry-all-errors**. Switching out curl for wget.

#### Issue Type

- Bugfix Pull Request

### Prerequisites

- [x] I have included documentation in my PR (or it is not required)
- [x] I have tested this by building an image using this branch HEAD, or this is does not pertain to the node-images pipeline.
 
### Idempotency
 
Yes
 
### Risks and Mitigations

None known