### PR TITLE
CASMTRIAGE-5839 Network template by driver

### DIFF
--- a/roles/node_images_ncn/files/cloud/templates/cloud-init-network.mlx.tmpl
+++ b/roles/node_images_ncn/files/cloud/templates/cloud-init-network.mlx.tmpl
@@ -1,0 +1,31 @@
+## template:jinja
+network:
+  version: 2
+  ethernets:
+    mgmt0:
+      dhcp6: no
+      mtu: 9000
+    mgmt1:
+      dhcp6: no
+      mtu: 9000
+  bonds:
+    bond0:
+      interfaces: [mgmt0, mgmt1]
+      dhcp4: false
+      mtu: 9000
+      parameters:
+        mode: 802.3ad
+        mii-monitor-interval: 100
+        lacp-rate: fast
+        ad-select: bandwidth
+        transmit-hash-policy: encap3+4
+  vlans:
+  {% for name, network in ds.meta_data.ipam.items() if network.vlanid != 0 %}
+  {{ network.parent_device }}.{{ name | lower }}0:
+      id: {{ network.vlanid }}
+      name: {{ name }}0
+      link: {{ network.parent_device }}
+      dhcp4: false
+      mtu: 9000
+      addresses: [ {{ network.ip }} ]
+  {% endfor %}

--- a/roles/node_images_ncn/files/cloud/templates/cloud-init-network.qede.tmpl
+++ b/roles/node_images_ncn/files/cloud/templates/cloud-init-network.qede.tmpl
@@ -1,0 +1,31 @@
+## template:jinja
+network:
+  version: 2
+  ethernets:
+    mgmt0:
+      dhcp6: no
+      mtu: 9000
+    mgmt1:
+      dhcp6: no
+      mtu: 9000
+  bonds:
+    bond0:
+      interfaces: [mgmt0, mgmt1]
+      dhcp4: false
+      mtu: 9000
+      parameters:
+        mode: 802.3ad
+        mii-monitor-interval: 100
+        lacp-rate: fast
+        ad-select: bandwidth
+        transmit-hash-policy: layer2
+  vlans:
+  {% for name, network in ds.meta_data.ipam.items() if network.vlanid != 0 %}
+  {{ network.parent_device }}.{{ name | lower }}0:
+      id: {{ network.vlanid }}
+      name: {{ name }}0
+      link: {{ network.parent_device }}
+      dhcp4: false
+      mtu: 9000
+      addresses: [ {{ network.ip }} ]
+  {% endfor %}


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: CASMTRIAGE-5839

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->
Apply a different cloud-init network template depending on the driver indentified on `mgmt0` to work around https://scc.suse.com/support/cases/00703657.
    
By default, apply our original layer2+3 config.
If Mellanox, apply encap3+4.
If QLogic, apply layer2.

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I have tested this by building an image using this branch HEAD, or this is does not pertain to the node-images pipeline.
- [ ] I tested this on internal system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
- [ ] I tested this on a vshasta system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
