### PR TITLE
ssh-import-id.service updates

### DIFF
--- a/roles/node_images_hypervisor/templates/systemd/ssh-import-id.service.j2
+++ b/roles/node_images_hypervisor/templates/systemd/ssh-import-id.service.j2
@@ -9,7 +9,8 @@ ExecCondition=/bin/bash -c '[ ! -f /etc/ssh/ssh_import_id.disabled ]'
 Environment=URL=http://{{ server_name }}/git/api/v1/repos/root/ssh-public-keys/raw/ssh-public-keys.json
 Environment=KEYS_FILE=/root/.ssh/authorized_keys
 ExecStartPre=/bin/bash -c 'install -d -m 700 /root/.ssh'
-ExecStart=/bin/bash -c "set -o pipefail; curl -f -sX 'GET' ${URL} -H 'accept: application/json' | jq -r '.ssh_authorized_keys[]' > ${KEYS_FILE}"
+ExecStart=/bin/bash -c "set -o pipefail; curl -f -sX 'GET' ${URL} -H 'accept: application/json' | jq -r '.ssh_authorized_keys[]' >> ${KEYS_FILE}"
+ExecStartPost=/bin/bash -c 'touch /etc/ssh/ssh_import_id.disabled'
 Restart=on-failure
 KillMode=control-group
 RemainAfterExit=true


### PR DESCRIPTION
### Summary and Scope

- append ssh keys instead of clobbering authorized_keys
- create /etc/ssh/ssh_import_id.disabled after successfully retrieving ssh keys from gitea

#### Issue Type


### Prerequisites


- [x] I have included documentation in my PR (or it is not required)
- [x] I have tested this by building an image using this branch HEAD, or this is does not pertain to the node-images pipeline.
 
 
### Risks and Mitigations
 
None known