### PR TITLE
remove Storage repos

### DIFF
--- a/group_vars/storage_ceph/packages.suse.yml
+++ b/group_vars/storage_ceph/packages.suse.yml
@@ -26,5 +26,4 @@ packages:
   - cephadm<17.2.7
   - golang-github-prometheus-node_exporter=1.5.0-150100.3.23.2
   - libfmt8=8.0.1-150400.1.8
-  - ses-release=7-64.1
   - smart-mon=1.0.3-1

--- a/scripts/repos/suse.template.repos
+++ b/scripts/repos/suse.template.repos
@@ -90,14 +90,3 @@ https://${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}@artifactory.algol60.net/artifac
 
 # SUSE PTF 1214447 systemd/udev
 https://${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}@artifactory.algol60.net/artifactory/suse-external/PTF.1214447/${releasever_major}-SP${releasever_minor}/${basearch}?auth=basic                                           SUSE-PTF.1214447                                        -g -p 89
-
-# These storage repos are only offered in x86_64
-https://${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}@artifactory.algol60.net/artifactory/sles-mirror/Products/Storage/7/x86_64/product?auth=basic                                                                             SUSE-Storage-7-x86_64-Pool                              -g -p 89
-#https://${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}@artifactory.algol60.net/artifactory/sles-mirror/Products/Storage/7/x86_64/product_debug?auth=basic                                                                       SUSE-Storage-7-x86_64-Debuginfo-Pool                    -g -p 89
-https://${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}@artifactory.algol60.net/artifactory/sles-mirror/Updates/Storage/7/x86_64/update?auth=basic                                                                               SUSE-Storage-7-x86_64-Updates                           -g -p 89
-#https://${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}@artifactory.algol60.net/artifactory/sles-mirror/Updates/Storage/7/x86_64/update_debug?auth=basic                                                                         SUSE-Storage-7-x86_64-Debuginfo-Updates                 -g -p 89
-
-#https://${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}@artifactory.algol60.net/artifactory/sles-mirror/Products/Storage/6/x86_64/product?auth=basic                                                                             SUSE-Storage-6-x86_64-Pool                              -g -p 89
-#https://${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}@artifactory.algol60.net/artifactory/sles-mirror/Products/Storage/6/x86_64/product_debug?auth=basic                                                                       SUSE-Storage-6-x86_64-Debuginfo-Pool                    -g -p 89
-https://${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}@artifactory.algol60.net/artifactory/sles-mirror/Updates/Storage/6/x86_64/update?auth=basic                                                                               SUSE-Storage-6-x86_64-Updates                           -g -p 89
-#https://${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}@artifactory.algol60.net/artifactory/sles-mirror/Updates/Storage/6/x86_64/update_debug?auth=basic                                                                         SUSE-Storage-6-x86_64-Debuginfo-Updates                 -g -p 89

--- a/vars/packages/csm.suse.yml
+++ b/vars/packages/csm.suse.yml
@@ -32,7 +32,7 @@ packages:
   - python3-PyYAML=5.4.1-1.1
   - python3-boto3=1.26.89-150200.23.12.1
   - python3-click=7.0-1.27
-  - python3-colorama=0.4.4-5.4.1
+  - python3-colorama=0.4.4-1.1
   - python3-defusedxml=0.6.0-1.42
   - python3-dmidecode=3.12.2-150400.14.3.1
   - python3-gobject=3.42.2-150400.3.3.2
@@ -46,6 +46,6 @@ packages:
   - python3-requests=2.24.0-150300.3.3.1
   - python3-rpm=4.14.3-150300.55.1
   - python3-six=1.14.0-12.1
-  - python3-urllib3=1.25.10-9.14.1
+  - python3-urllib3=1.25.10-4.3.1
   - python3-websocket-client=1.3.2-150100.6.7.3
   - spire-agent=1.5.5-1.8


### PR DESCRIPTION
### Summary and Scope

Suse Storage/6 and Storage/7 repos are deprecated so we're going to stop using them.

#### Issue Type

- Bugfix Pull Request

### Prerequisites

- [x] I have included documentation in my PR (or it is not required)
- [x] I have tested this by building an image using this branch HEAD, or this is does not pertain to the node-images pipeline.
- [x] I tested this on internal system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)

 
### Risks and Mitigations

Downgrading several packages and removing one.
python3-urllib3
python3-colorama
ses-release