### PR TITLE
CASMTRIAGE-6017: fix setup-nexus script silent failure

### DIFF
--- a/scripts/nexus/setup-nexus.sh
+++ b/scripts/nexus/setup-nexus.sh
@@ -662,7 +662,10 @@ if [ "$delete" -ne 0 ]; then
 elif [ "$server" -ne 0 ]; then
     echo "Uploading RPMs from $CSM_PATH/rpms ... "
     setup-apache2-https-proxy
-    setup-nexus-server
+    if ! setup-nexus-server; then
+        echo >&2 'Failed to setup nexus server! Aborting.'
+        exit 1
+    fi
 elif [ "$upload" -ne 0 ]; then
     echo "Uploading files from $repo_path to $repo_name ... "
     nexus-create-repo "${repo_name}" "${repo_type:-raw}"


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Relates to: [CASMTRIAGE-6017](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-6017)

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->
When setup-nexus script runs into error, it often fails silently. This PR makes the error bubble up, enabling the caller to be aware and handle the errors accordingly.

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I have tested this by building an image using this branch HEAD, or this is does not pertain to the node-images pipeline.
- [ ] I tested this on internal system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
- [ ] I tested this on a vshasta system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations

Low. 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
