### PR TITLE
CASMINST-6654: Make sure that test failures are logged when CMS Goss tests are unable to run

### DIFF
--- a/group_vars/ncn/packages.suse.yml
+++ b/group_vars/ncn/packages.suse.yml
@@ -74,7 +74,7 @@ packages:
   - cloud-init=21.4-1
   - cray-kubectl-hns-plugin=1.0.2-1
   - cray-kubectl-kubelogin-plugin=1.25.3-1
-  - goss-servers=1.17.6-1
+  - goss-servers=1.16.54-1
   - hpe-csm-scripts=0.6.2-1
   - hpe-yq=4.33.3-1
   - loftsman=1.2.0-3


### PR DESCRIPTION
I also noticed that the wrong major/minor version of goss-servers was being used in the CSM 1.5 branch of this repo. Not sure when that got introduced, but this PR also moves it back to using the correct major/minor for CSM 1.5.

`metal-provision` CSM 1.5 PR for https://github.com/Cray-HPE/csm/pull/2842
