### PR TITLE
CASMINST-6654/CASMINST-6657: Make sure that test failures are logged when CMS Goss tests are unable to run; fix RPM versions

### DIFF
--- a/group_vars/compute/packages.suse.yml
+++ b/group_vars/compute/packages.suse.yml
@@ -29,7 +29,7 @@ packages:
   - csm-auth-utils=1.0.0-1
   - csm-node-heartbeat=2.3-1
   # CMS Team
-  - bos-reporter=2.6.3-1
+  - bos-reporter=2.8.0-1
   - cfs-debugger=1.5.0-1
   - cfs-state-reporter=1.10.1-1
   - cfs-trust=1.6.8-1

--- a/group_vars/kubernetes/packages.suse.yml
+++ b/group_vars/kubernetes/packages.suse.yml
@@ -30,7 +30,7 @@ packages:
   # CSM
   # platform-utils is also installed by cloud-init. However, we need to *also* bake it in
   # for proper vshasta-v2 functionality.
-  - platform-utils=1.6.4-1
+  - platform-utils=1.6.5-1
   # Metal
   - dracut-metal-dmk8s=2.1.1-1
   - dracut-metal-luksetcd=2.1.1-1

--- a/group_vars/ncn/packages.suse.yml
+++ b/group_vars/ncn/packages.suse.yml
@@ -74,7 +74,7 @@ packages:
   - cloud-init=21.4-1
   - cray-kubectl-hns-plugin=1.0.2-1
   - cray-kubectl-kubelogin-plugin=1.25.3-1
-  - goss-servers=1.17.6-1
+  - goss-servers=1.17.7-1
   - hpe-csm-scripts=0.6.2-1
   - hpe-yq=4.33.3-1
   - loftsman=1.2.0-3


### PR DESCRIPTION
`metal-provision` CSM 1.6 PR for https://github.com/Cray-HPE/csm/pull/2842

I also added a commit for [CASMINST-6657](https://jira-pro.it.hpe.com:8443/browse/CASMINST-6657) to address a couple of other RPM versions which are out of sync for what we should be using for CSM 1.6.