### PR TITLE
CASMINST-6658: Add Goss server endpoint for Kubernetes cluster tests

### DIFF
--- a/group_vars/ncn/packages.suse.yml
+++ b/group_vars/ncn/packages.suse.yml
@@ -74,7 +74,7 @@ packages:
   - cloud-init=21.4-1
   - cray-kubectl-hns-plugin=1.0.2-1
   - cray-kubectl-kubelogin-plugin=1.25.3-1
-  - goss-servers=1.17.7-1
+  - goss-servers=1.17.8-1
   - hpe-csm-scripts=0.6.2-1
   - hpe-yq=4.33.3-1
   - loftsman=1.2.0-3


### PR DESCRIPTION
CSM 1.6 backport of https://github.com/Cray-HPE/metal-provision/pull/490