### PR TITLE
MTL-2278 This is not actually broken

### DIFF
--- a/scripts/nexus/setup-nexus.sh
+++ b/scripts/nexus/setup-nexus.sh
@@ -334,21 +334,15 @@ function setup-nexus-server() {
             name="$(basename "$directory")"
             # Name distro specific repos with their distro name in lower case.
             repo_name="csm-$CSM_RELEASE-${name,,}"
-# FIXME: MTL-2278 switch back to yum.
-#            if ! nexus-create-repo "$repo_name" yum; then
-            if ! nexus-create-repo "$repo_name" raw; then
+            if ! nexus-create-repo "$repo_name" yum; then
                 echo >&2 "Failed to create repo: $repo_name. Aborting."
                 return 1
             fi
-# FIXME: MTL-2278 switch back to yum.
-#            if ! nexus-create-repo-group-yum "csm-${name,,}" "$repo_name"; then
-            if ! nexus-create-repo-group-raw "csm-${name,,}" "$repo_name"; then
+            if ! nexus-create-repo-group-yum "csm-${name,,}" "$repo_name"; then
                 echo >&2 "Failed to create repo group: csm-${name,,}"
                 return 1
             fi
-# FIXME: MTL-2278 switch back to yum.
-#            if ! nexus-upload-yum "${directory}" "${repo_name}"; then
-            if ! nexus-upload-raw "${directory}" "${repo_name}"; then
+            if ! nexus-upload-yum "${directory}" "${repo_name}"; then
                 echo >&2 "Failed to upload $directory to $repo_name! Aborting."
                 return 1
             fi


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: MTL-2278

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->
False alarm.

The YUM repos are working, the 500 HTTP errors we encountered earlier were due to bad RPMs.

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I have tested this by building an image using this branch HEAD, or this is does not pertain to the node-images pipeline.
- [ ] I tested this on internal system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
- [ ] I tested this on a vshasta system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
