### PR TITLE
MTL-2280: spire and dhcp hostname

### DIFF
--- a/group_vars/compute/services.suse.yml
+++ b/group_vars/compute/services.suse.yml
@@ -38,3 +38,6 @@ services:
   - enabled: true
     name: csm-node-identity.service
     state: stopped
+  - enabled: true
+    name: spire-agent.service
+    state: stopped

--- a/roles/node_images_compute/tasks/main.yml
+++ b/roles/node_images_compute/tasks/main.yml
@@ -53,3 +53,10 @@
     path: /etc/fstab
     state: absent
     regexp: '^LABEL=ROOTRAID.*'
+
+- name: Configure dhcp settings
+  ansible.builtin.lineinfile:
+    path: /etc/sysconfig/network/dhcp
+    regexp: "{{ item.regexp }}"
+    line: "{{ item.line }}"
+  loop: "{{ dhcp }}"


### PR DESCRIPTION
### Summary and Scope

Enable spire-agent and allow dhcp hostnames to be set

- Fixes: [MTL-2280](https://jira-pro.it.hpe.com:8443/browse/MTL-2280)

#### Issue Type

- Bugfix Pull Request

Compute and Application nodes require that spire-agent be running for things like BOS and CFS to work correctly.

### Prerequisites

- [x] I have included documentation in my PR (or it is not required)
- [x] I have tested this by building an image using this branch HEAD, or this is does not pertain to the node-images pipeline.
- [x] I tested this on internal system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
- [ x I tested this on a vshasta system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
Tested on `beau`
 
### Idempotency
 
Should be
 
### Risks and Mitigations
 
Low, Image can be modified via CFS image customization to address issues until fixed. Image used for validation primarily.