### PR TITLE
CASMINST-6663: Prevent Goss tests from failing due to missing environment variable

### DIFF
--- a/group_vars/ncn/packages.suse.yml
+++ b/group_vars/ncn/packages.suse.yml
@@ -74,7 +74,7 @@ packages:
   - cloud-init=21.4-1
   - cray-kubectl-hns-plugin=1.0.2-1
   - cray-kubectl-kubelogin-plugin=1.25.3-1
-  - goss-servers=1.17.10-1
+  - goss-servers=1.17.11-1
   - hpe-csm-scripts=0.6.2-1
   - hpe-yq=4.33.3-1
   - loftsman=1.2.0-3


### PR DESCRIPTION
https://github.com/Cray-HPE/csm/pull/2869