### PR TITLE
`hosts.suse.tmpl.j2` is rendering incorrectly

### DIFF
--- a/roles/node_images_management_vm/templates/cloud/templates/hosts.suse.tmpl.j2
+++ b/roles/node_images_management_vm/templates/cloud/templates/hosts.suse.tmpl.j2
@@ -1,4 +1,4 @@
-{% raw %}
+{% raw -%}
 ## template:jinja
 {#
 This file /etc/cloud/templates/hosts.suse.tmpl is only utilized
@@ -30,5 +30,6 @@ ff00::0 ipv6-mcastprefix
 ff02::1 ipv6-allnodes
 ff02::2 ipv6-allrouters
 ff02::3 ipv6-allhosts
-{% endraw %}
+{% endraw -%}
 {{ isolated_network | ansible.utils.ipaddr('first_usable') }} hypervisor.local hypervisor
+{{ isolated_network | ansible.utils.ipaddr('last_usable') }} management-vm.local management-vm

--- a/scripts/repos/cray.template.repos
+++ b/scripts/repos/cray.template.repos
@@ -1,10 +1,10 @@
 # CSM / CLOUD / PET / MTL / NET
 https://${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}@artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos?auth=basic                                                                                                cray-algol60-csm-rpms-stable-noos                                                          --no-gpgcheck -p 87
-https://${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}@artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-${releasever_major}sp${releasever_minor}?auth=basic                                                        cray-algol60-csm-rpms-stable-sle-${releasever_major}sp${releasever_minor}                  --no-gpgcheck -p 88
+https://${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}@artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-${releasever_major}sp${releasever_minor}?auth=basic                                                        'cray-algol60-csm-rpms-stable-sle-${releasever_major}sp${releasever_minor}'                  --no-gpgcheck -p 88
 
 # Fawkes
 https://${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}@artifactory.algol60.net/artifactory/fawkes-rpms/hpe/stable/noos?auth=basic                                                                                             cray-algol60-fawkes-rpms-stable-noos                                                       --no-gpgcheck -p 87
-https://${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}@artifactory.algol60.net/artifactory/fawkes-rpms/hpe/stable/sle-${releasever_major}sp${releasever_minor}?auth=basic                                                     cray-algol60-fawkes-rpms-stable-sle-${releasever_major}sp${releasever_minor}               --no-gpgcheck -p 88
+https://${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}@artifactory.algol60.net/artifactory/fawkes-rpms/hpe/stable/sle-${releasever_major}sp${releasever_minor}?auth=basic                                                     'cray-algol60-fawkes-rpms-stable-sle-${releasever_major}sp${releasever_minor}'               --no-gpgcheck -p 88
 
 
 # SAT


### PR DESCRIPTION
The `hosts.suse.tmpl.j2` file is rendering with a blank line at the top of file, this blank line is preventing the template from rendering its variables during cloud-init.

With the blank line, the rendered `/etc/hosts` still contains `{{fqdn}}` and `{{hostname}}`.

This ensures there's no leading blank line after the `{% raw %}` block start.

Also adds the nodes expected, isolated IP to the template.