### PR TITLE
MTL-2274

### DIFF
--- a/group_vars/management_vm/packages.suse.yml
+++ b/group_vars/management_vm/packages.suse.yml
@@ -27,6 +27,7 @@ packages:
   - apparmor-profiles=3.0.4-150500.11.3.1
   - conman=0.3.1-150500.1.2
   - dnsmasq=2.86-150400.14.3
+  - fawkes-httpboot-grub=1.0-1
   - gnu_parallel=20230122-bp155.1.5
   - gnu_parallel-bash-completion=20230122-bp155.1.5
   - gnu_parallel-zsh-completion=20230122-bp155.1.5
@@ -36,5 +37,3 @@ packages:
   - metal-observability=1.0.9-1
   - sqlite3=3.39.3-150000.3.20.1
   - terraform=0.13.4-6.3.1
-  - tftpboot-installation-SLE-15-SP5-aarch64=16.58.6-150500.1.6
-  - tftpboot-installation-SLE-15-SP5-x86_64=16.58.6-150500.1.6

--- a/roles/bootserver/defaults/main.yml
+++ b/roles/bootserver/defaults/main.yml
@@ -37,14 +37,3 @@ dhcp:
 interface_mtl: eth1
 interface_hmn: eth2
 interface_ext: eth3
-
-bootloaderx64: bootx64.efi
-bootloaderx64_path: "/usr/share/tftpboot-installation/\
-  SLE-{{ ansible_distribution_major_version }}-SP{{ ansible_distribution_release }}-\
-  x86_64/EFI/BOOT/{{ bootloaderx64 }}"
-bootloaderaa64: bootaa64.efi
-bootloaderaa64_path: "/usr/share/tftpboot-installation/\
-  SLE-{{ ansible_distribution_major_version }}-SP{{ ansible_distribution_release }}-\
-  aarch64/EFI/BOOT/{{ bootloaderaa64 }}"
-grub_binary: grub.efi
-grub_path: "/usr/share/efi/{{ ansible_architecture }}/{{ grub_binary }}"

--- a/roles/bootserver/tasks/main.yml
+++ b/roles/bootserver/tasks/main.yml
@@ -63,18 +63,6 @@
   notify:
     - 'bootserver : Restart dnsmasq'
 
-- name: Bootloader symlinks
-  ansible.builtin.file:
-    src: "{{ item.src }}"
-    dest: "{{ item.dest }}"
-    owner: root
-    group: root
-    state: link
-  loop:
-    - {src: "{{ bootloaderaa64_path }}", dest: "{{ web_root }}/boot/{{ bootloaderaa64 }}"}
-    - {src: "{{ bootloaderx64_path }}", dest: "{{ web_root }}/boot/{{ bootloaderx64 }}"}
-    - {src: "{{ grub_path }}", dest: "{{ web_root }}/boot/{{ grub_binary }}"}
-
 - name: Update apparmor's dnsmasq profile for the webroot
   ansible.builtin.lineinfile:
     path: /etc/apparmor.d/usr.sbin.dnsmasq

--- a/roles/grub/templates/grub.conf.j2
+++ b/roles/grub/templates/grub.conf.j2
@@ -32,7 +32,7 @@ lang=en_US
 menuentry 'LiveCD' {
   set gfxpayload=keep
   echo 'Loading kernel ...'
-  linuxefi (http,{{ server_name }}){{ kernel_path }} {{ kernel_params | join(' ') }}
+  linux (http,{{ server_name }}){{ kernel_path }} {{ kernel_params | join(' ') }}
   echo 'Loading initrd ...'
-  initrdefi (http,{{ server_name }}){{ initrd_path }}
+  initrd (http,{{ server_name }}){{ initrd_path }}
 }


### PR DESCRIPTION
### Summary and Scope

Update to use our *fawkes-httpboot-grub* rpm, vs. using the SLES tftpboot-installation-SLE-15-SP5 rpm's.
Relates to: https://jira-pro.it.hpe.com:8443/browse/MTL-2274

#### Issue Type

- RFE Pull Request

### Prerequisites

- [x] I have included documentation in my PR (or it is not required)
- [x] I have tested this by building an image using this branch HEAD, or this is does not pertain to the node-images pipeline.
- [x] I tested this on internal system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
 
### Risks and Mitigations

Few risks, but it does reduce the size on disk from 1GB to 30MB.