### PR TITLE
CASMHMS-6072: Bump hpe-csm-scripts version

### DIFF
--- a/group_vars/ncn/packages.suse.yml
+++ b/group_vars/ncn/packages.suse.yml
@@ -75,7 +75,7 @@ packages:
   - cray-kubectl-hns-plugin=1.0.2-1
   - cray-kubectl-kubelogin-plugin=1.25.3-1
   - goss-servers=1.17.11-1
-  - hpe-csm-scripts=0.6.2-1
+  - hpe-csm-scripts=0.7.0-1
   - hpe-yq=4.33.3-1
   - loftsman=1.2.0-3
   - manifestgen=1.3.10-1


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: CASMHMS-6072

#### Issue Type

<!--- Delete un-needed bullets -->

- RFE Pull Request

<!--- words; describe what this change is and what it is for. -->

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I have tested this by building an image using this branch HEAD, or this is does not pertain to the node-images pipeline.
- [ ] I tested this on internal system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
- [ ] I tested this on a vshasta system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
Tested updated `run_hms_ct_tests.sh` for REDS removal and it worked. For testing see: https://github.com/Cray-HPE/hpe-csm-scripts/pull/60

### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
No known issues.