### PR TITLE
CASMPET-6814: Add new RPMs for spire TPM

### DIFF
--- a/group_vars/compute/packages.suse.x86_64.yml
+++ b/group_vars/compute/packages.suse.x86_64.yml
@@ -23,6 +23,8 @@
 #
 ---
 packages_x86_64:
+  # CSM Packages
+  - cray-spire-dracut=2.0.1-1
   # COS SHASTA-OS packages
   # - cray-cos-release                    : Installed cle and cos release files.
   - cray-cos-release=1.4.0-2.6_20230804001533__gc3d4504a78a1

--- a/vars/packages/suse.x86_64.yml
+++ b/vars/packages/suse.x86_64.yml
@@ -52,3 +52,5 @@ packages_x86_64:
   # rationale: Provides a mechanism to release updates for security advisories and functional issues.
   - ucode-amd=20230724-150500.3.6.1
   - ucode-intel=20230808-150200.27.1
+  # rationale: Necessary for enabling TPM based identification for spire.
+  - tpm-provisioner-client=1.0.1-2


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: [CASMPET-6814](https://jira-pro.it.hpe.com:8443/browse/CASMPET-6814)

#### Issue Type

<!--- Delete un-needed bullets -->

- RFE Pull Request

<!--- words; describe what this change is and what it is for. -->
Allows for TPM to be enabled on nodes.

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [x] I have included documentation in my PR (or it is not required)
- [x] I have tested this by building an image using this branch HEAD, or this is does not pertain to the node-images pipeline.
- [x] I tested this on internal system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
- [x] I tested this on a vshasta system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
I added a new rpm that only adds some new binaries, and a dracut module that still works the same way as in current dracut developed by cos.

### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
There is low risk as it only brings in a new dracut which has backwards compatibility with the old dracut. And a new rpm that is not normally ran