### PR TITLE
CRAYSAT-1774: Update version of cray-sat-podman and remove sat-rpms repo

### DIFF
--- a/group_vars/kubernetes/packages.suse.yml
+++ b/group_vars/kubernetes/packages.suse.yml
@@ -38,6 +38,6 @@ packages:
   - insserv-compat=0.1-4.6.1
   # SAT
   - cray-prodmgr=1.3.0-1
-  - cray-sat-podman=2.0.0-1
+  - cray-sat-podman=2.1.0-1
   # SDU
   - cray-sdu-rda=2.1.3-shasta_20221024161411_0800580

--- a/scripts/repos/cray.template.repos
+++ b/scripts/repos/cray.template.repos
@@ -6,10 +6,6 @@ https://${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}@artifactory.algol60.net/artifac
 https://${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}@artifactory.algol60.net/artifactory/fawkes-rpms/hpe/stable/noos?auth=basic                                                                                             cray-algol60-fawkes-rpms-stable-noos                                                       --no-gpgcheck -p 87
 https://${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}@artifactory.algol60.net/artifactory/fawkes-rpms/hpe/stable/sle-${releasever_major}sp${releasever_minor}?auth=basic                                                     'cray-algol60-fawkes-rpms-stable-sle-${releasever_major}sp${releasever_minor}'               --no-gpgcheck -p 88
 
-
-# SAT
-https://${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}@artifactory.algol60.net/artifactory/sat-rpms/hpe/stable/sle-15sp3?auth=basic                                                                                           cray-algol60-sat-rpms-stable-sle-15sp3                                                     --no-gpgcheck -p 90
-
 # COS
 https://${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}@artifactory.algol60.net/artifactory/dst-rpm-mirror/cos-rpm-stable-local/release/cos-2.6/sle${releasever_major}_sp${releasever_minor}_ncn?auth=basic                   cray-cos-sle-2.6-SHASTA-OS-cos-ncn                                                          --no-gpgcheck -p 89
 


### PR DESCRIPTION
### Summary and Scope

The `cray-sat-podman` RPM has been moved from the sat-rpms repository in Artifactory to the csm-rpms repository. Its version has also been incremented from 2.0.0-1 to 2.1.0-1. Update the version of this package included in the Kubernetes NCN images, and remove the sat-rpms repository, which is no longer used for any RPMs included here.

- Fixes: CRAYSAT-1774

#### Issue Type

- RFE Pull Request

### Prerequisites

- [x] I have included documentation in my PR (or it is not required)
- [x] I have tested this by building an image using this branch HEAD, or this is does not pertain to the node-images pipeline.
- [x] I tested this on internal system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
 
### Idempotency
 
Unsure.
 
### Risks and Mitigations
 
This should be low-risk. It doesn't change any functionality. As long as the images build, it should be okay.