### PR TITLE
Run `write-files` before `bootcmd`

### DIFF
--- a/roles/cloud_init/files/cloud/cloud.cfg
+++ b/roles/cloud_init/files/cloud/cloud.cfg
@@ -29,8 +29,8 @@ ssh:
 cloud_init_modules:
     - migrator
     - seed_random
-    - bootcmd
     - write-files
+    - bootcmd
     - growpart
     - resizefs
     - disk_setup


### PR DESCRIPTION
For fawkes we have a need to run `write-files` to install scripts that we want to call in `bootcmd`. It doesn't hurt to run `write-files` first, so we'll just change the order here.
