### PR TITLE
MTL-2000 Enable zypper cloud-init modules

### DIFF
--- a/roles/node_images_ncn/files/cloud.cfg
+++ b/roles/node_images_ncn/files/cloud.cfg
@@ -12,6 +12,8 @@ cloud_init_modules :
 #    - resolv_conf
     - disk_setup
     - mounts
+    - zypper_add_repo
+    - package_update_upgrade_install
 # timezone is a custom module and should run BEFORE ntp runs
     - timezone
 # this is a custom ntp module and should run AFTER the timezone is set

--- a/roles/node_images_ncn_metal/files/scripts/metal/install.sh
+++ b/roles/node_images_ncn_metal/files/scripts/metal/install.sh
@@ -120,10 +120,6 @@ csm() {
     printf 'Metal Install: [ % -20s ]\n' "running: BMC Reset" >&2
     [ -n "$METAL_TIME" ] && time bmc_reset || bmc_reset
     
-    # 5. 
-    printf 'Metal Install: [ % -20s ]\n' 'running: CSM layer' >&2
-    [ -n "$METAL_TIME" ] && time csm || csm
-
 ) >/var/log/cloud-init-metal.log
 
 printf 'Metal Install: [ % -20s ]\n' 'done and complete'

--- a/roles/node_images_ncn_metal/files/scripts/metal/metal-lib.sh
+++ b/roles/node_images_ncn_metal/files/scripts/metal/metal-lib.sh
@@ -469,6 +469,7 @@ function paginate() {
 }
 
 function install_csm_rpms() {
+    echo >&2 "This function is deprecated, its function has been replaced by cloud-init."
     local repos
     local cani_url
     local canu_url


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: MTl-2000

#### Issue Type

<!--- Delete un-needed bullets -->

- RFE Pull Request

<!--- words; describe what this change is and what it is for. -->
Enables repository setup and package installation from cloud-init, using the zypper and packages cloud-init modules.

This deprecates and disables the package install hack (`install_csm_rpms`).

This change depends on the following cloud-init user-data existing:

```bash

ncn-m001:~ # cray bss bootparameters list --format json --hosts $(cat /etc/cray/xname) | jq '.[]."cloud-init"."user-data".packages'
[
    "cani",
    "canu",
    "cray-cmstools-crayctldeploy",
    "csm-testing",
    "goss-servers",
    "iuf-cli",
    "libcsm",
    "platform-utils"
]
```

```bash
ncn-m001:~ # cray bss bootparameters list --format json --hosts $(cat /etc/cray/xname) | jq '.[]."cloud-init"."user-data".zypper'
{
  "repos": [
    {
      "autorefresh": 1,
      "baseurl": "https://packages.local/repository/csm-noos?ssl_verify=no",
      "enabled": 1,
      "gpgcheck": 1,
      "id": "csm-noos",
      "name": "csm-noos",
      "repo_gpgcheck": 0
    },
    {
      "autorefresh": 1,
      "baseurl": "https://packages.local/repository/csm-sle-${releasever_major}sp${releasever_minor}?ssl_verify=no",
      "enabled": 1,
      "gpgcheck": 1,
      "id": "csm-sle",
      "name": "csm-sle-${releasever_major}sp${releasever_minor}",
      "repo_gpgcheck": 0
    }
  ]
}
```

The above snippet was confirmed on a csm-1.5.0-beta.64 upgrade, and was confirmed on a CSM 1.5 fresh install at an earlier date.

The Zypper repo information in the snippet was used manually and resulted in successfully adding the repository.

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I have tested this by building an image using this branch HEAD, or this is does not pertain to the node-images pipeline.
- [ ] I tested this on internal system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
- [ ] I tested this on a vshasta system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->

#### Zypper Module Test

On fanta, after confirming the user-data was available I ran the `zypper_add_repo` module by itself. This yielded working repositories.

```bash
ncn-s001:~ # cray bss bootparameters list --format json --hosts $(cat /etc/cray/xname) | jq '.[]."cloud-init"."user-data".zypper'
{
  "repos": [
    {
      "autorefresh": 1,
      "baseurl": "https://packages.local/repository/csm-noos?ssl_verify=no",
      "enabled": 1,
      "gpgcheck": 1,
      "id": "csm-noos",
      "name": "csm-noos",
      "repo_gpgcheck": 0
    },
    {
      "autorefresh": 1,
      "baseurl": "https://packages.local/repository/csm-sle-${releasever_major}sp${releasever_minor}?ssl_verify=no",
      "enabled": 1,
      "gpgcheck": 1,
      "id": "csm-sle",
      "name": "csm-sle-${releasever_major}sp${releasever_minor}",
      "repo_gpgcheck": 0
    }
  ]
}
ncn-s001:~ # zypper repos
Repository priorities are without effect. All enabled repositories share the same priority.

# | Alias         | Name                                         | Enabled | GPG Check | Refresh
--+---------------+----------------------------------------------+---------+-----------+--------
1 | csm-embedded  | CSM Embedded NCN Packages (added by Ansible) | Yes     | ( p) Yes  | Yes
2 | csm-sle-15sp2 | CSM SLE 15 SP2 Packages (added by Ansible)   | Yes     | ( p) Yes  | Yes
3 | csm-sle-15sp3 | CSM SLE 15 SP3 Packages (added by Ansible)   | Yes     | ( p) Yes  | Yes
4 | csm-sle-15sp4 | CSM SLE 15 SP4 Packages (added by Ansible)   | Yes     | ( p) Yes  | Yes
```

I edited the local cache, merging in what was in BSS. I did this to avoid sprawling my testing.
```bash
ncn-s001:~ # vim /var/lib/cloud/instance/cloud-config.txt
```

Then I added the `zypper_add_repo` module to `cloud.cfg` for good measure.
```bash
ncn-s001:~ # vim /etc/cloud/cloud.cfg
```

Finally, I ran the new module standalone.
```bash
cloud-init -d single --name zypper_add_repo --frequency always
```

The `cloud-init.log` showed the creation of the `.repo` files:
```bash
2023-10-13 16:08:28,129 - helpers.py[DEBUG]: Running config-zypper_add_repo using lock (<cloudinit.helpers.DummyLock object at 0x7fe2b543a390>)
2023-10-13 16:08:28,130 - util.py[DEBUG]: Writing to /etc/zypp/repos.d/csm-noos.repo - wb: [644] 152 bytes
2023-10-13 16:08:28,130 - util.py[DEBUG]: Writing to /etc/zypp/repos.d/csm-sle.repo - wb: [644] 231 bytes
```

I confirmed Zypper was aware of the new repos, and that they could be refreshed/scanned.
```bash
ncn-s001:/var/lib/cloud/instance # zypper repos
Repository priorities are without effect. All enabled repositories share the same priority.

# | Alias         | Name                                         | Enabled | GPG Check | Refresh
--+---------------+----------------------------------------------+---------+-----------+--------
1 | csm-embedded  | CSM Embedded NCN Packages (added by Ansible) | Yes     | ( p) Yes  | Yes
2 | csm-noos      | csm-noos                                     | Yes     | ( p) Yes  | Yes
3 | csm-sle       | csm-sle-15sp3                                | Yes     | ( p) Yes  | Yes
4 | csm-sle-15sp2 | CSM SLE 15 SP2 Packages (added by Ansible)   | Yes     | ( p) Yes  | Yes
5 | csm-sle-15sp3 | CSM SLE 15 SP3 Packages (added by Ansible)   | Yes     | ( p) Yes  | Yes
6 | csm-sle-15sp4 | CSM SLE 15 SP4 Packages (added by Ansible)   | Yes     | ( p) Yes  | Yes
ncn-s001:/var/lib/cloud/instance # zypper ref
Retrieving repository 'CSM Embedded NCN Packages (added by Ansible)' metadata ......................................................................................................................................................................................................[done]
Building repository 'CSM Embedded NCN Packages (added by Ansible)' cache ...........................................................................................................................................................................................................[done]
Retrieving repository 'csm-noos' metadata ..........................................................................................................................................................................................................................................[done]
Building repository 'csm-noos' cache ...............................................................................................................................................................................................................................................[done]
Retrieving repository 'csm-sle-15sp3' metadata .....................................................................................................................................................................................................................................[done]
Building repository 'csm-sle-15sp3' cache ..........................................................................................................................................................................................................................................[done]
Retrieving repository 'CSM SLE 15 SP2 Packages (added by Ansible)' metadata ........................................................................................................................................................................................................[done]
Building repository 'CSM SLE 15 SP2 Packages (added by Ansible)' cache .............................................................................................................................................................................................................[done]
Retrieving repository 'CSM SLE 15 SP3 Packages (added by Ansible)' metadata ........................................................................................................................................................................................................[done]
Building repository 'CSM SLE 15 SP3 Packages (added by Ansible)' cache .............................................................................................................................................................................................................[done]
Retrieving repository 'CSM SLE 15 SP4 Packages (added by Ansible)' metadata ........................................................................................................................................................................................................[done]
Building repository 'CSM SLE 15 SP4 Packages (added by Ansible)' cache .............................................................................................................................................................................................................[done]
All repositories have been refreshed.
```

Lastly, the `.repo` files looked as I expected them to.

```bash
ncn-s001:/var/lib/cloud/instance # cat /etc/zypp/repos.d/csm-noos.repo
[csm-noos]
autorefresh = 1
baseurl = https://packages.local/repository/csm-noos?ssl_verify=no
enabled = 1
gpgcheck = 1
name = csm-noos
repo_gpgcheck = 0ncn-s001:/var/lib/cloud/instance # cat /etc/zypp/repos.d/csm-
csm-embedded.repo   csm-noos.repo       csm-sle-15sp2.repo  csm-sle-15sp3.repo  csm-sle-15sp4.repo  csm-sle.repo
ncn-s001:/var/lib/cloud/instance # cat /etc/zypp/repos.d/csm-sle.repo
[csm-sle]
autorefresh = 1
baseurl = https://packages.local/repository/csm-sle-${releasever_major}sp${releasever_minor}?ssl_verify=no
enabled = 1
gpgcheck = 1
name = csm-sle-${releasever_major}sp${releasever_minor}
repo_gpgcheck = 0ncn-s001:/var/lib/cloud/instance #
```

#### Package Module Test

```bash
ncn-s001:~ # cloud-init -d single --name package_update_upgrade_install --frequency always
... // truncated to relevant portion by Russell Bunch
2023-10-13 16:23:44,442 - main.py[DEBUG]: Logging being reset, this logger may no longer be active shortly
Cloud-init v. 21.4-1 running 'single' at Fri, 13 Oct 2023 16:23:44 +0000. Up 123723.14 seconds.
Repository 'CSM Embedded NCN Packages (added by Ansible)' is up to date.
Repository 'csm-noos' is up to date.
Repository 'csm-sle-15sp3' is up to date.
Repository 'CSM SLE 15 SP2 Packages (added by Ansible)' is up to date.
Repository 'CSM SLE 15 SP3 Packages (added by Ansible)' is up to date.
Repository 'CSM SLE 15 SP4 Packages (added by Ansible)' is up to date.
All repositories have been refreshed.
Loading repository data...
Reading installed packages...
Resolving package dependencies...

The following 6 packages are going to be upgraded:
  canu cray-cmstools-crayctldeploy csm-testing goss-servers iuf-cli platform-utils

The following 2 NEW packages are going to be installed:
  cani libcsm

The following 8 packages have no support information from their vendor:
  cani canu cray-cmstools-crayctldeploy csm-testing goss-servers iuf-cli libcsm platform-utils

6 packages to upgrade, 2 new.
Overall download size: 130.8 MiB. Already cached: 0 B. After the operation, additional 127.5 MiB will be used.
Continue? [y/n/v/...? shows all options] (y): y
Retrieving package cani-0.3.0-1.x86_64 (1/8),   6.5 MiB ( 14.6 MiB unpacked)
Retrieving: cani-0.3.0-1.x86_64.rpm [done]
Retrieving package canu-1.7.6-1.x86_64 (2/8),  87.0 MiB ( 88.9 MiB unpacked)
Retrieving: canu-1.7.6-1.x86_64.rpm [.done (66.9 MiB/s)]
Retrieving package cray-cmstools-crayctldeploy-1.14.1-1.x86_64 (3/8),  15.1 MiB ( 40.9 MiB unpacked)
Retrieving: cray-cmstools-crayctldeploy-1.14.1-1.x86_64.rpm [done]
Retrieving package csm-testing-1.16.59-1.noarch (4/8), 155.0 KiB (  1.1 MiB unpacked)
Retrieving: csm-testing-1.16.59-1.noarch.rpm [done]
Retrieving package goss-servers-1.16.59-1.noarch (5/8),  12.4 KiB (  6.1 KiB unpacked)
Retrieving: goss-servers-1.16.59-1.noarch.rpm [done]
Retrieving package iuf-cli-1.5.6-1.x86_64 (6/8),  11.4 MiB ( 11.7 MiB unpacked)
Retrieving: iuf-cli-1.5.6-1.x86_64.rpm [done]
Retrieving package platform-utils-1.6.7-1.noarch (7/8),  24.0 KiB ( 64.0 KiB unpacked)
Retrieving: platform-utils-1.6.7-1.noarch.rpm [done]
Retrieving package libcsm-0.0.5-1.noarch (8/8),  10.5 MiB (111.4 MiB unpacked)
Retrieving: libcsm-0.0.5-1.noarch.rpm [done]

Checking for file conflicts: [......done]
(1/8) Installing: cani-0.3.0-1.x86_64 [............done]
(2/8) Installing: canu-1.7.6-1.x86_64 [...............done]
(3/8) Installing: cray-cmstools-crayctldeploy-1.14.1-1.x86_64 [.............done]
(4/8) Installing: csm-testing-1.16.59-1.noarch [...................done]
(5/8) Installing: goss-servers-1.16.59-1.noarch [........done]
(6/8) Installing: iuf-cli-1.5.6-1.x86_64 [............done]
(7/8) Installing: platform-utils-1.6.7-1.noarch [...............done]
(8/8) Installing: libcsm-0.0.5-1.noarch [............done]
There are running programs which still use files and libraries deleted or updated by recent upgrades. They should be restarted to benefit from the latest updates. Run 'zypper ps -s' to list these programs.

ncn-s001:~ #
```

### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
This ceases calling the `install_csm_scripts` function, but leaves the function in place with a deprecation notice in case it is needed as a workaround.