### PR TITLE
MTL-2237 tarball updates

### DIFF
--- a/roles/bootserver/tasks/main.yml
+++ b/roles/bootserver/tasks/main.yml
@@ -72,20 +72,3 @@
     state: present
   notify:
     - 'bootserver : Restart apparmor'
-
-- name: Make ephemeral
-  ansible.builtin.file:
-    mode: '0755'
-    owner: root
-    group: root
-    state: directory
-    path: '{{ web_root }}/ephemeral'
-
-- name: Mount the hypervisor ISO
-  ansible.posix.mount:
-    path: "{{ web_root }}/ephemeral"
-    src: /vms/assets/images/hypervisor-{{ ansible_architecture }}.iso
-    fstype: iso9660
-    state: mounted
-    boot: false
-    opts: ro

--- a/roles/bootserver/templates/dnsmasq.conf.j2
+++ b/roles/bootserver/templates/dnsmasq.conf.j2
@@ -6,8 +6,7 @@ group=tftp
 # and packets with private IP addresses from leaving our scoped network.
 domain-needed
 bogus-priv
-# Never serve external or isolated networks:
-except-interface=eth0
+# Never serve external networks:
 except-interface={{ interface_ext }}
 # DHCP:
 domain=local

--- a/roles/bootserver/templates/dnsmasq.d/boot.conf.j2
+++ b/roles/bootserver/templates/dnsmasq.d/boot.conf.j2
@@ -29,8 +29,8 @@ dhcp-vendorclass=efi-arm64-sb-http,HTTPClient:Arch:00013
 dhcp-option-force=tag:efi-x86_64-sb-http,60,HTTPClient
 dhcp-option-force=tag:efi-arm64-sb-http,60,HTTPClient
 
-dhcp-boot=tag:efi-x86_64-sb-http,"http://{{ server_name }}/boot/{{ bootloaderx64 }}"
-dhcp-boot=tag:efi-arm64-sb-http,"http://{{ server_name }}/boot/{{ bootloaderaa64 }}"
+dhcp-boot=tag:efi-arm64-sb-http,"http://{{ server_name }}/boot/bootaa64.efi"
+dhcp-boot=tag:efi-x86_64-sb-http,"http://{{ server_name }}/boot/bootx64.efi"
 
 interface-name={{ server_name }},{{ interface_mtl }}
 interface-name=packages,{{ interface_mtl }}

--- a/roles/grub/defaults/main.yml
+++ b/roles/grub/defaults/main.yml
@@ -22,9 +22,10 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 ---
-iso_url: "http://{{ server_name }}/nexus/repository/os-images/hypervisor/hypervisor-{{ ansible_architecture }}.iso"
-kernel_path: "/ephemeral/boot/{{ ansible_architecture }}/loader/kernel"
-initrd_path: "/ephemeral/boot/{{ ansible_architecture }}/loader/initrd.img.xz"
+iso_urn: ''
+iso_url: "http://{{ server_name }}/nexus/repository/fawkes-images/{{ iso_urn }}"
+kernel_path: "/nexus/repository/fawkes-images/hypervisor/boot/{{ ansible_architecture }}/loader/kernel"
+initrd_path: "/nexus/repository/fawkes-images/hypervisor/boot/{{ ansible_architecture }}/loader/initrd.img.xz"
 kernel_params:
   - biosdevname=1
   - console=tty0

--- a/roles/grub/tasks/main.yml
+++ b/roles/grub/tasks/main.yml
@@ -1,4 +1,15 @@
 ---
+- name: Resolve available hypervisor ISO
+  ansible.builtin.uri:
+    url: "http://bootserver/nexus/service/rest/v1/search/assets?q=hypervisor&repository=fawkes-images"
+    method: GET
+    return_content: true
+  register: result
+
+- name: Set iso_urn
+  ansible.builtin.set_fact:
+    iso_urn: "{{ result.content | from_json | json_query('items[*].path') | select('search', 'iso$') | list | first }}"
+
 - name: Grub templates
   ansible.builtin.template:
     mode: '0644'


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: MTL-2237
- Relates to: #517 

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request
- RFE Pull Request

<!--- words; describe what this change is and what it is for. -->

To test this, I uploaded a tarball from https://github.com/Cray-HPE/fawkes/pull/15 and then PXE booting a hypervisor node on redbull.

Generated `grub.cfg` file:
```
#
# MIT License
#
# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
#
# Permission is hereby granted, free of charge, to any person obtaining a
# copy of this software and associated documentation files (the "Software"),
# to deal in the Software without restriction, including without limitation
# the rights to use, copy, modify, merge, publish, distribute, sublicense,
# and/or sell copies of the Software, and to permit persons to whom the
# Software is furnished to do so, subject to the following conditions:
#
# The above copyright notice and this permission notice shall be included
# in all copies or substantial portions of the Software.
#
# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
# OTHER DEALINGS IN THE SOFTWARE.
#
---
gfxmode=auto
timeout=2
default=1

locale_dir=$prefix/grub.locale
lang=en_US

menuentry 'LiveCD' {
  set gfxpayload=keep
  echo 'Loading kernel ...'
  linux (http,bootserver)/nexus/repository/fawkes-images/hypervisor/boot/x86_64/loader/kernel biosdevname=1 console=tty0 console=ttyS0,115200 crashkernel=360M iommu=pt ip=dhcp pcie_ports=native psi=1 rd.live.ram=1 rd.md.conf=0 rd.md=0 rd.neednet=1 rd.peerdns=1 rd.shell root=live:http://bootserver/nexus/repository/fawkes-images/hypervisor/hypervisor-6.1.37-x86_64.iso split_lock_detect=off transparent_hugepage=never
  echo 'Loading initrd ...'
  initrd (http,bootserver)/nexus/repository/fawkes-images/hypervisor/boot/x86_64/loader/initrd.img.xz
}
```

Output from PXE booting using the above `grub.cfg` file:
```bash
management-vm:/vms/assets/fawkes-0.0.1-alpha.1-6-geedf65c # conman -j ncn-h004-mgmt

<ConMan> Connection to console [ncn-h004-mgmt] opened.

<ConMan> Console [ncn-h004-mgmt] joined with <root@localhost> on pts/0 at 10-18 16:44.

                           GNU GRUB  version 2.12~rc1

 /----------------------------------------------------------------------------\
 |*LiveCD                                                                     |
 |                                                                            |
 |                                                                            |
 |                                                                            |
 |                                                                            |
 |                                                                            |
 |                                                                            |
 |                                                                            |
 |                                                                            |
 |                                                                            |
 |                                                                            |
 |                                                                            |
 \----------------------------------------------------------------------------/

      Use the ^ and v keys to select which entry is highlighted.
      Press enter to boot the selected OS, `e' to edit the commands
      before booting or `c' for a command-line. ESC to return previous
      menu.

                           GNU GRUB  version 2.12~rc1

   Minimal BASH-like line editing is supported. For the first word, TAB
   lists possible command completions. Anywhere else TAB lists possible
   device or file completions. To enable less(1)-like paging, "set
   pager=1". ESC at any time exits.


grub> exit
/------------------------------------------------------------------------------\
|                                Boot Manager                                  |
\------------------------------------------------------------------------------/

                                                         Select this option to
   UEFI Samsung Flash Drive 1100                         boot now.
   Launch EFI Shell                                      Note: This list is
   UEFI IPv4: Network 00 at Riser 03 Slot 01             not the system boot
   UEFI HTTPv6: Network 00 at Riser 03 Slot 01           option order. Use the
   UEFI HTTPv4: Network 00 at Riser 03 Slot 01           Boot Maintenance
   UEFI IPv6: Network 00 at Riser 03 Slot 01             Manager menu to view
   UEFI IPv4: Network 01 at Riser 03 Slot 01             and configure the
   UEFI HTTPv6: Network 01 at Riser 03 Slot 01           system boot option
   UEFI HTTPv4: Network 01 at Riser 03 Slot 01           order.
   UEFI IPv6: Network 01 at Riser 03 Slot 01





/------------------------------------------------------------------------------\
|                         F10=Save Changes and Exit F9=Reset to Defaults       |
| ^v=Move Highlight       <Enter>=Select Entry      Esc=Exit                   |
\-----------------Copyright (c) 2006-2023, Intel Corporation-------------------/

  Station IP address is 10.1.0.10

  URI: http://bootserver/boot/bootx64.efierror: efinet0: can't open protocol.
error: couldn't autoconfigure efinet0.
error: can't find command `---'.

                           GNU GRUB  version 2.12~rc1

 /----------------------------------------------------------------------------\
 |*LiveCD                                                                     |
 |                                                                            |
 |                                                                            |
 |                                                                            |
 |                                                                            |
 |                                                                            |
 |                                                                            |
 |                                                                            |
 |                                                                            |
 |                                                                            |
 |                                                                            |
 |                                                                            |
 \----------------------------------------------------------------------------/

      Use the ^ and v keys to select which entry is highlighted.
      Press enter to boot the selected OS, `e' to edit the commands
      before booting or `c' for a command-line. ESC to return previous
      menu.
Loading kernel ...
Loading initrd ...
EFI stub: Loaded initrd from LINUX_EFI_INITRD_MEDIA_GUID device path
[    0.000000][    T0] microcode: microcode updated early to revision 0x2007006, date = 2023-03-06
[    0.000000][    T0] Linux version 5.14.21-150500.55.28.1.26977.2.PTF.1214754-default (geeko@buildhost) (gcc (SUSE Linux) 7.5.0, GNU ld (GNU Binutils; SUSE Linux Enterprise 15) 2.41.0.20230908-150100.7.46) #1 SMP PREEMPT_DYNAMIC Thu Oct 5 04:17:52 UTC 2023 (ac35ff8)
[    0.000000][    T0] Command line: BOOT_IMAGE=(http,bootserver)/nexus/repository/fawkes-images/hypervisor/boot/x86_64/loader/kernel biosdevname=1 console=tty0 console=ttyS0,115200 crashkernel=360M iommu=pt ip=dhcp pcie_ports=native psi=1 rd.live.ram=1 rd.md.conf=0 rd.md=0 rd.neednet=1 rd.peerdns=1 rd.shell root=live:http://bootserver/nexus/repository/fawkes-images/hypervisor/hypervisor-6.1.37-x86_64.iso split_lock_detect=off transparent_hugepage=never
```

Some minor changes this PR also includes:
- Fixes to #517 for missing variables
- DNSMasq tweaks

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I have tested this by building an image using this branch HEAD, or this is does not pertain to the node-images pipeline.
- [x] I tested this on internal system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
- [ ] I tested this on a vshasta system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
