### PR TITLE
MTL-2262: ensure `fstab.metal` exists before trying to reference it

### DIFF
--- a/roles/node_images_ncn/files/systemd/metalfs.service
+++ b/roles/node_images_ncn/files/systemd/metalfs.service
@@ -5,6 +5,7 @@ Before=containerd.service etcd.service kubelet.service
 [Service]
 Type=oneshot
 ExecStartPre=/bin/bash -c '(while ! /sbin/blkid | grep -q BOOTRAID; do echo "metalfs: waiting for BOOTRAID volume..."; sleep 1; done; sleep 1);'
+ExecStartPre=/bin/bash -c '(while ! [ -f /etc/fstab.metal ]; do echo "metalfs: waiting for /etc/fstab.metal to exist..."; sleep 1; done; sleep 1);'
 ExecCondition=/bin/bash -c "[ -f /etc/fstab.metal ]"
 ExecStart=/usr/bin/mount -a -T /etc/fstab.metal
 RemainAfterExit=false


### PR DESCRIPTION
### Summary and Scope

There is a race condition such that BOOTRAID exists, but /etc/fstab.metal might not exist until ~1 second after that. This caused the ExecCondition to fail.


<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: MTL-2262

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [x] I have included documentation in my PR (or it is not required)
- [x] I have tested this by building an image using this branch HEAD, or this is does not pertain to the node-images pipeline.
- [x] I tested this on internal system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
- [x] I tested this on a vshasta system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
