### PR TITLE
CASMTRIAGE-6201 (1.6)

### DIFF
--- a/roles/node_images_ncn/files/cloud.cfg
+++ b/roles/node_images_ncn/files/cloud.cfg
@@ -12,8 +12,6 @@ cloud_init_modules :
 #    - resolv_conf
     - disk_setup
     - mounts
-    - zypper_add_repo
-    - package_update_upgrade_install
 # timezone is a custom module and should run BEFORE ntp runs
     - timezone
 # this is a custom ntp module and should run AFTER the timezone is set
@@ -22,6 +20,8 @@ cloud_config_modules :
     - write_files
     - runcmd
 cloud_final_modules :
+    - zypper_add_repo
+    - package_update_upgrade_install
     - scripts-vendor
     - scripts-per-once
     - scripts-per-boot


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: CASMTRIAGE-6201

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->
DNS is unreliably set up before `runcmd` is ran, and at scale (even with only 9 nodes) it is possible that the repo URLs do not resolve.

Move `zypper_add_repo` and `package_update_upgrade_install` from `init` to `final`. Ensuring it runs after `runcmd` runs.

Optionally we could've moved these to _before_ `bootcmd`, since `runcmd` invokes our `net-init.sh` script which in turn re-runs `cloud-init init`. `bootcmd` naturally fails on subsequent runs, so anything after `bootcmd` and before `cloud-init config` never get another shot. That means moving these _before_ `bootcmd` should have the same or better effect. We might go that route if we encounter another issue with this.

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I have tested this by building an image using this branch HEAD, or this is does not pertain to the node-images pipeline.
- [ ] I tested this on internal system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
- [ ] I tested this on a vshasta system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
