### PR TITLE
Update platform-utils to fix etcd cluster balance check (CASMPET-6827)

### DIFF
--- a/group_vars/kubernetes/packages.suse.yml
+++ b/group_vars/kubernetes/packages.suse.yml
@@ -30,7 +30,7 @@ packages:
   # CSM
   # platform-utils is also installed by cloud-init. However, we need to *also* bake it in
   # for proper vshasta-v2 functionality.
-  - platform-utils=1.6.7-1
+  - platform-utils=1.6.8-1
   # Metal
   - dracut-metal-dmk8s=2.1.1-1
   - dracut-metal-luksetcd=2.1.1-1


### PR DESCRIPTION
### Summary and Scope

Fix etcd cluster balance test to account for defrag pod (hbtd)

### Issues and Related PRs

  * CASMPET-6827: etcd cluster balance check needs to avoid defrag pods

### Testing

mug:
```
ncn-m001:/mnt/developer/bklein # kubectl get po -n services | grep cray-hbtd-bitnami-etcd
cray-hbtd-bitnami-etcd-0                                          2/2     Running            352 (17h ago)      13d
cray-hbtd-bitnami-etcd-1                                          2/2     Running            361 (17h ago)      13d
cray-hbtd-bitnami-etcd-2                                          2/2     Running            2506 (17h ago)     13d
cray-hbtd-bitnami-etcd-snapshotter-28304220-8rdhn                 0/2     Completed          0                  38m
kube-etcd-defrag-cray-hbtd-bitnami-etcd-28304234-4t6ph            0/2     Completed          0                  24m
```

```
ncn-m001:/mnt/developer/bklein # ./ncnHealthChecks.sh -s etcd_cluster_balance
**************************************************************************

=== Check the Number of Pods in Each Cluster. Verify they are Balanced. ===
=== Each cluster should contain at least three pods, but may contain more. ===
=== Ensure that no two pods in a given cluster exist on the same worker node. ===
Wed 25 Oct 2023 05:35:34 PM UTC
cray-bos-bitnami-etcd-0                                           2/2     Running            0                7d      10.38.0.42     k8s-worker0-ncn-w008   <none>           <none>
cray-bos-bitnami-etcd-1                                           2/2     Running            0                7d      10.41.128.8    ncn-w002               <none>           <none>
cray-bos-bitnami-etcd-2                                           2/2     Running            0                7d      10.34.128.21   ncn-w004               <none>           <none>

cray-bss-bitnami-etcd-0                                           2/2     Running            3 (153m ago)     34d     10.33.0.60     ncn-w011               <none>           <none>
cray-bss-bitnami-etcd-1                                           2/2     Running            7 (34d ago)      89d     10.32.0.95     ncn-w001               <none>           <none>
cray-bss-bitnami-etcd-2                                           2/2     Running            2 (34d ago)      47d     10.35.0.2      ncn-w003               <none>           <none>

cray-etcd-test-bitnami-etcd-0                                     2/2     Running            49 (34d ago)     82d     10.45.0.35     ncn-w010               <none>           <none>
cray-etcd-test-bitnami-etcd-1                                     2/2     Running            53 (34d ago)     82d     10.32.0.85     ncn-w001               <none>           <none>
cray-etcd-test-bitnami-etcd-2                                     2/2     Running            52 (34d ago)     82d     10.44.0.4      ncn-w002               <none>           <none>

cray-fas-bitnami-etcd-0                                           2/2     Running            9 (34d ago)      103d    10.44.0.10     ncn-w002               <none>           <none>
cray-fas-bitnami-etcd-1                                           2/2     Running            2 (34d ago)      77d     10.45.0.33     ncn-w010               <none>           <none>
cray-fas-bitnami-etcd-2                                           2/2     Running            8 (34d ago)      47d     10.32.0.77     ncn-w001               <none>           <none>

cray-hbtd-bitnami-etcd-0                                          2/2     Running            352 (17h ago)    13d     10.33.0.13     ncn-w011               <none>           <none>
cray-hbtd-bitnami-etcd-1                                          2/2     Running            361 (17h ago)    13d     10.38.0.30     k8s-worker0-ncn-w008   <none>           <none>
cray-hbtd-bitnami-etcd-2                                          2/2     Running            2506 (17h ago)   13d     10.43.0.29     ncn-w009               <none>           <none>

cray-hmnfd-bitnami-etcd-0                                         2/2     Running            0                13d     10.35.0.32     ncn-w003               <none>           <none>
cray-hmnfd-bitnami-etcd-1                                         2/2     Running            1 (13d ago)      13d     10.33.0.61     ncn-w011               <none>           <none>
cray-hmnfd-bitnami-etcd-2                                         2/2     Running            0                13d     10.43.0.41     ncn-w009               <none>           <none>

cray-power-control-bitnami-etcd-0                                 2/2     Running            8 (155m ago)       103d    10.32.0.94     ncn-w001               <none>           <none>
cray-power-control-bitnami-etcd-1                                 2/2     Running            3 (34d ago)        103d    10.35.0.38     ncn-w003               <none>           <none>
cray-power-control-bitnami-etcd-2                                 2/2     Running            6 (34d ago)        47d     10.44.0.22     ncn-w002               <none>           <none>

cray-uas-mgr-bitnami-etcd-0                                       2/2     Running            11 (34d ago)       103d    10.32.0.13     ncn-w001               <none>           <none>
cray-uas-mgr-bitnami-etcd-1                                       2/2     Running            2 (34d ago)        103d    10.45.0.54     ncn-w010               <none>           <none>
cray-uas-mgr-bitnami-etcd-2                                       2/2     Running            6 (34d ago)        103d    10.35.0.5      ncn-w003               <none>           <none>

 --- PASSED ---
```

Was a fresh Install tested? N
Was an Upgrade tested?      N - N/A
Was a Downgrade tested?     N - N/A
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

### Risks and Mitigations

Low

### Requires:

* Nothing

