### PR TITLE
CRAYSAT-1767: Update cray-sat-podman RPM version for CSM 1.6.0

### DIFF
--- a/group_vars/kubernetes/packages.suse.yml
+++ b/group_vars/kubernetes/packages.suse.yml
@@ -38,6 +38,6 @@ packages:
   - insserv-compat=0.1-4.6.1
   # SAT
   - cray-prodmgr=1.3.0-1
-  - cray-sat-podman=2.1.0-1
+  - cray-sat-podman=3.0.0-1
   # SDU
   - cray-sdu-rda=2.1.3-shasta_20230912173723_0800580a3dc6


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Relates to: CRAYSAT-1771 and CRAYSAT-1767

#### Issue Type

<!--- Delete un-needed bullets -->

- RFE Pull Request

<!--- words; describe what this change is and what it is for. -->

Update the version of the cray-sat-podman RPM to 3.0.0 for CSM 1.6.0. This new version uses the new path to the cray-sat container image in Nexus where it is uploaded by CSM 1.6.0.

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [x] I have included documentation in my PR (or it is not required)
- [ ] I have tested this by building an image using this branch HEAD, or this is does not pertain to the node-images pipeline.
- [x] I tested this on internal system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
- [x] I tested this on a vshasta system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
 
### Idempotency
 
No changes to idempotency.
 
### Risks and Mitigations
 
This new version of the `cray-sat-podman` will use a new default path in Nexus for the `cray-sat` container image, and the change that will upload the `cray-sat` container image to this new path is https://github.com/Cray-HPE/csm/pull/2962

This change is only intended for CSM 1.6.0. We should try to merge this PR at the same time as the aforementioned csm PR.

If we mess up the timing of these two PRs, the result will be that `sat` commands will complain about not being able to find the `cray-sat` container image. Such a problem can be worked around by setting environment variables supported by the `sat-podman` wrapper script.