### PR TITLE
CASMPET-6835:  Change kube-proxy-replacement to cilium-kube-proxy-replacement in CSI

### DIFF
--- a/group_vars/fawkes_live/packages.suse.yml
+++ b/group_vars/fawkes_live/packages.suse.yml
@@ -24,6 +24,6 @@
 ---
 packages:
   # rationale: Application for facilitating configuring a hypervisor node.
-  - crucible=0.0.13-1
+  - crucible=0.0.14-1
   # rationale: Used for poking around the system
   - gru=0.0.4-1

--- a/group_vars/hypervisor/packages.suse.yml
+++ b/group_vars/hypervisor/packages.suse.yml
@@ -26,7 +26,7 @@ packages:
   # rationale: Security.
   - apparmor-profiles=3.0.4-150500.11.6.1
   # rationale: Application for facilitating configuring a hypervisor node.
-  - crucible=0.0.13-1
+  - crucible=0.0.14-1
   # rationale: Free range routing.
   - frr=8.4-150500.4.8.1
   # rationale: Necessary for Mercury software proof-of-concepts.

--- a/group_vars/pre_install_toolkit/packages.suse.yml
+++ b/group_vars/pre_install_toolkit/packages.suse.yml
@@ -29,7 +29,7 @@ packages:
   - wol=0.7.1-2.5
   # CSM
   - canu=1.7.6-1
-  - cray-site-init=1.32.4-1
+  - cray-site-init=1.32.5-1
   - ilorest=4.2.0.0-20
   - metal-basecamp=1.2.6-1
   - metal-ipxe=2.4.6-1


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes:  https://jira-pro.it.hpe.com:8443/browse/CASMPET-6835

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->

Changes kube-proxy-replacement to cilium-kube-proxy-replacement to match up with kubernetes-cloudinit.sh.

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [x] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)
 
Built CSI binary locally and ran csi config init both with and without cilium-kube-proxy-replacement defined in system_config.yaml. Verified that the correct value was generated in data.json.

### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
