### PR TITLE
MTL-2346 `craysys` update for newer cloud-init

### DIFF
--- a/group_vars/ncn/packages.suse.yml
+++ b/group_vars/ncn/packages.suse.yml
@@ -67,10 +67,10 @@ packages:
   - cfs-debugger=1.5.0-1
   - cfs-state-reporter=1.11.0-1
   - cfs-trust=1.6.8-1
-  # cloud-init: Must use 23.2.1-1, specifically our forked build in csm-rpms
-  - cloud-init-config-suse=23.2.1-1
-  - cloud-init-doc=23.2.1-1
-  - cloud-init=23.2.1-1
+  # cloud-init: Must use 23.2.2-1, specifically our forked build in csm-rpms
+  - cloud-init-config-suse=23.2.2-1
+  - cloud-init-doc=23.2.2-1
+  - cloud-init=23.2.2-1
   - cray-kubectl-hns-plugin=1.0.2-1
   - cray-kubectl-kubelogin-plugin=1.25.3-1
   - goss-servers=1.17.12-1

--- a/roles/node_images_ncn/files/utilities/common/craysys/metal.py
+++ b/roles/node_images_ncn/files/utilities/common/craysys/metal.py
@@ -40,7 +40,6 @@ class Metal:
             #
             # cloud-init converts dashes, so we'll do the same
             #
-            key = key.replace('-', '_')
             resp = self.execute("cloud-init query -a")
             if level == 'node':
                 return resp['ds']['meta_data'][key]


### PR DESCRIPTION


### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: MTL-2346
- Relates to: #574 

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->
Fixes `ModuleNotFoundError: No module named 'DataSourcenocloud-net` (https://github.com/canonical/cloud-init/issues/4302) by pulling in cloud-init 23.2.2.

Since we adopted cloud-init 22+ in #574, based on [this commit](https://github.com/Cray-HPE/node-images/commit/51dc8d48e9bb791e2f2f3e1d3dec0b4de0ab610b) we also need to remove line 43 from `craysys`' `metal.py`.

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I have tested this by building an image using this branch HEAD, or this is does not pertain to the node-images pipeline.
- [ ] I tested this on internal system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
- [x] I tested this on a vshasta system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
