### PR TITLE
Fix conditional check when `patterns` is undefined

### DIFF
--- a/roles/packages/tasks/main.yml
+++ b/roles/packages/tasks/main.yml
@@ -83,7 +83,7 @@
         oldpackage: true
         state: present
         update_cache: false
-      when: patterns | length != 0
+      when: patterns is defined and patterns | length != 0
 
     - name: (ZYPPER) Install architecture specific packages
       community.general.zypper:


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: https://github.com/Cray-HPE/node-images/actions/runs/7006953829/job/19060052972#step:11:4966 
- Relates to: #576 

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->
When `patterns` is undefined this conditional fails with a fatal error. This started happening after lint fixes from #576.
### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I have tested this by building an image using this branch HEAD, or this is does not pertain to the node-images pipeline.
- [ ] I tested this on internal system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
- [ ] I tested this on a vshasta system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
