### PR TITLE
CASMCVT-252:adding latest vers of cvt

### DIFF
--- a/group_vars/ncn/packages.suse.yml
+++ b/group_vars/ncn/packages.suse.yml
@@ -81,6 +81,6 @@ packages:
   # CM cli
   - cm-cli=1.5.1-1
   # CVT
-  - cvt=1.5.10-20230925110721_8760a8d6d7bd
+  - cvt=1.5.16-20231117084626_6a46ee25062e
   # SMA
   - sma-cli-utils=1.5.4-1


### PR DESCRIPTION
### Summary and Scope

[CASMCVT-252](https://jira-pro.it.hpe.com:8443/browse/CASMCVT-252)

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: Latest fixes have been included for CVT and CDS
- Requires: new version built to be included
- Relates to: cvt-1.5.16-20231117084626_6a46ee25062e.x86_64.rpm

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request
- Docs Pull Request
- RFE Pull Request

<!--- words; describe what this change is and what it is for. -->

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I have tested this by building an image using this branch HEAD, or this is does not pertain to the node-images pipeline.
- [ ] I tested this on internal system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
- [ ] I tested this on a vshasta system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
