### PR TITLE
CASMINST-6730: Add Goss test to verify that all Kubernetes NCNs are at the same level

### DIFF
--- a/group_vars/ncn/packages.suse.yml
+++ b/group_vars/ncn/packages.suse.yml
@@ -73,7 +73,7 @@ packages:
   - cloud-init=23.2.2-1
   - cray-kubectl-hns-plugin=1.0.2-1
   - cray-kubectl-kubelogin-plugin=1.25.3-1
-  - goss-servers=1.17.12-1
+  - goss-servers=1.17.18-1
   - hpe-csm-scripts=0.7.0-1
   - hpe-yq=4.33.3-1
   - loftsman=1.2.0-3


### PR DESCRIPTION
metal-provision 1.6 PR for https://github.com/Cray-HPE/csm/pull/3070