### PR TITLE
CASMINST-6730: Add Goss test to verify that all Kubernetes NCNs are at the same level

### DIFF
--- a/group_vars/ncn/packages.suse.yml
+++ b/group_vars/ncn/packages.suse.yml
@@ -74,7 +74,7 @@ packages:
   - cloud-init=21.4-1
   - cray-kubectl-hns-plugin=1.0.2-1
   - cray-kubectl-kubelogin-plugin=1.25.3-1
-  - goss-servers=1.16.58-1
+  - goss-servers=1.16.64-1
   - hpe-csm-scripts=0.5.7-1
   - hpe-yq=4.33.3-1
   - loftsman=1.2.0-3


### PR DESCRIPTION
metal-provision CSM 1.5 PR for https://github.com/Cray-HPE/csm/pull/3070