### PR TITLE
MTL-2351 and MTL-2352

### DIFF
--- a/group_vars/management_vm/packages.suse.yml
+++ b/group_vars/management_vm/packages.suse.yml
@@ -33,7 +33,7 @@ packages:
   - gnu_parallel-zsh-completion=20230122-bp155.1.5
   - gru=0.0.4-1
   - metal-init=1.4.6-1
-  - metal-ipxe=2.5.0-1
+  - metal-ipxe=2.5.1-1
   - metal-nexus=1.4.0-3.38.0_1
   - metal-observability=1.0.9-1
   - sqlite3=3.39.3-150000.3.20.1

--- a/group_vars/pre_install_toolkit/packages.suse.yml
+++ b/group_vars/pre_install_toolkit/packages.suse.yml
@@ -32,7 +32,7 @@ packages:
   - cray-site-init=1.32.5-1
   - ilorest=4.2.0.0-20
   - metal-basecamp=1.2.6-1
-  - metal-ipxe=2.4.6-1
+  - metal-ipxe=2.4.7-1
   - metal-init=1.4.6-1
   - metal-nexus=1.4.0-3.38.0_1
   - metal-observability=1.0.9-1


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: MTL-2351 MTL-2352

#### Issue Type

<!--- Delete un-needed bullets -->

- RFE Pull Request

<!--- words; describe what this change is and what it is for. -->
MTL-2351 adds broadcom support to CSM 1.5 and CSM 1.6 for fresh installs.

MTL-2352 is a minor update that fixes a compilation error for ipxe with binutils 2.41, but as far as fawkes is concerned there's no functional change.

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I have tested this by building an image using this branch HEAD, or this is does not pertain to the node-images pipeline.
- [ ] I tested this on internal system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
- [ ] I tested this on a vshasta system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
