### PR TITLE
Fix qemu dependency

### DIFF
--- a/group_vars/hypervisor/packages.suse.yml
+++ b/group_vars/hypervisor/packages.suse.yml
@@ -33,9 +33,5 @@ packages:
   - libguestfs0=1.48.6-150500.3.5.1
   # rationale: Necessary for Mercury software proof-of-concepts.
   - libxslt-tools=1.1.34-150400.3.3.1
-  # rationale: Drivers for VMs.
-  - qemu=7.1.0-150500.49.6.1
-  # rationale: Necessary for providing consoles to VMs.
-  - qemu-ui-spice-core=7.1.0-150500.49.6.1
   # rationale: Necessary for providing timezone zoneinfo definition files.
   - timezone=2023c-150000.75.23.1

--- a/vars/packages/libvirt.suse.yml
+++ b/vars/packages/libvirt.suse.yml
@@ -26,3 +26,5 @@ packages:
   - libvirt-client=9.0.0-150500.6.11.1
   - libvirt-devel=9.0.0-150500.6.11.1
   - libvirt=9.0.0-150500.6.11.1
+  - qemu=7.1.0-150500.49.9.2
+  - qemu-ui-spice-core=7.1.0-150500.49.9.2


### PR DESCRIPTION
Install qemu when installing libvirt in order to work around https://github.com/Cray-HPE/node-images/actions/runs/7200009942/job/19613032823?pr=1029#step:10:3748

Libvirt is finding newer dependencies, that do not align with the designated qemu version. By installing qemu at the same time as libvirt, Zypper will ensure it pulls matching dependencies in.

This also updates qemu to the newer version.
