### PR TITLE
CASMHMS-6116 wrong csm node heartbeat

### DIFF
--- a/group_vars/compute/packages.suse.yml
+++ b/group_vars/compute/packages.suse.yml
@@ -27,7 +27,7 @@ packages:
   # CSM Team
   - acpid=2.0.31-2.1
   - csm-auth-utils=1.0.0-1
-  - csm-node-heartbeat=2.4-1
+  - csm-node-heartbeat=2.5-1
   # CMS Team
   - bos-reporter=2.9.0-1
   - cfs-debugger=1.5.0-1

--- a/vars/packages/csm.suse.yml
+++ b/vars/packages/csm.suse.yml
@@ -25,7 +25,7 @@
 packages:
   - craycli=0.82.10-1
   - csm-auth-utils=1.0.0-1
-  - csm-node-heartbeat=2.4-1
+  - csm-node-heartbeat=2.5-1
   - csm-node-identity=1.0.22-1
   - python3-Jinja2=2.10.1-3.10.2
   - python3-MarkupSafe=1.0-1.29


### PR DESCRIPTION
### Summary and Scope

- Fixes: [CASMHMS-6116](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6116)

#### Issue Type

- Docs Pull Request

Starlord's management nodes are not properly sending heartbeats because spire filtering is turned On. The csm-node-heartbeat RPM installed is version 2.4. This is incorrect for a CSM 1.5 system. We need to use the 2.5 version of the RPM because it contains both the spire path change and heartbeat URL change required for node to properly heartbeat when spire filtering is On.

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [X] I have included documentation in my PR (or it is not required)
- [X] I have tested this by building an image using this branch HEAD, or this is does not pertain to the node-images pipeline.
- [X] I tested this on internal system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
- [] I tested this on a vshasta system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
 
### Idempotency

Manually deployed the updated csm-node-heartbeat.sh file onto nid 18 and restarted csm-node-heartbeat service, resulting service status included the xname in the URL and HBTD received the heartbeat notification and the node went from On to Ready.
 
### Risks and Mitigations
 
No known risks.
