### PR TITLE
Fawkes runthrough bugfixes and tweaks

### DIFF
--- a/group_vars/hypervisor/networks.yml
+++ b/group_vars/hypervisor/networks.yml
@@ -22,8 +22,8 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 ---
-network_default_mtu: 9000
-networks:
+network_manager_default_mtu: 9000
+network_manager_hypervisor_networks:
   interfaces:
     ethernets:
       - name: mgmt0

--- a/roles/network_manager/tasks/main.yml
+++ b/roles/network_manager/tasks/main.yml
@@ -23,7 +23,7 @@
 #
 ---
 
-- name: Find wired connections
+- name: Find any unwanted wired connections
   ansible.builtin.shell: |
     set -o pipefail
     nmcli connection | grep Wired | wc -l


### PR DESCRIPTION
I ran through another Fawkes install using the latest images (from before break) and I hit one problem with the `network_manager` role.

I included an amendment for a task name as well.