### PR TITLE
CASMINST-6766 Remediate extraneous errors observed during `setup-nexus` when updating the Docker registry

### DIFF
--- a/roles/node_images_pre_install_toolkit/files/apache2/nexus.conf
+++ b/roles/node_images_pre_install_toolkit/files/apache2/nexus.conf
@@ -1,28 +1,78 @@
 # Necessary for the IP, pit, and pit.nmn to not be proxied.
+
+# Allow access to all nexus sub-paths.
+<LocationMatch "^/nexus/.*">
+    <IfModule !mod_access_compat.c>
+        Require all granted
+    </IfModule>
+    <IfModule mod_access_compat.c>
+        Order allow,deny
+        Allow from all
+    </IfModule>
+</LocationMatch>
+
 <VirtualHost *:80>
-  ServerName pit.nmn
+    ProxyPreserveHost On
+    AllowEncodedSlashes NoDecode
+    ProxyRequests Off
+    ServerName fawkes
+    RewriteEngine On
+
+    # https://help.sonatype.com/repomanager3/planning-your-implementation/run-behind-a-reverse-proxy#RunBehindaReverseProxy-Apachehttpd.1
+    RewriteRule "^/nexus$" "/nexus/" [R]
+    <Location "/nexus/">
+        ProxyPass http://localhost:8081/nexus/
+        ProxyPassReverse http://localhost:8081/nexus/
+    </Location>
 </VirtualHost>
 
-# Necessary for packages to proxy to nexus.
+# Necessary for http://packages/ to proxy to nexus.
 <VirtualHost *:80>
-  ProxyPreserveHost On
-  ProxyRequests Off
-  AllowEncodedSlashes NoDecode
-  ProxyTimeout 300
-  ServerName packages
-  ServerAlias packages
-  ProxyPass / http://localhost:8081/nexus/ nocanon
-  ProxyPassReverse / http://localhost:8081/nexus/
+    ProxyPreserveHost On
+    ProxyRequests Off
+    AllowEncodedSlashes NoDecode
+    ProxyTimeout 300
+    ServerName packages
+    ServerAlias packages
+    RewriteEngine On
+    RewriteCond expr "! %{REQUEST_URI} =~ m#^/nexus/#"
+    RewriteRule "^/(.*)$" "/nexus/$1" [R=308]
+    <Location "/nexus/">
+        ProxyPass http://localhost:8081/nexus/ nocanon
+        ProxyPassReverse http://localhost:8081/nexus/
+    </Location>
 </VirtualHost>
 
-# Necessary for packages.nmn to proxy to nexus.
+# Necessary for http://packages.mtl/ to proxy to nexus.
 <VirtualHost *:80>
-  ProxyPreserveHost On
-  ProxyRequests Off
-  AllowEncodedSlashes NoDecode
-  ProxyTimeout 300
-  ServerName packages.nmn
-  ServerAlias packages.nmn
-  ProxyPass / http://localhost:8081/nexus/ nocanon
-  ProxyPassReverse / http://localhost:8081/nexus/
+    ProxyPreserveHost On
+    ProxyRequests Off
+    AllowEncodedSlashes NoDecode
+    ProxyTimeout 300
+    ServerName packages.mtl
+    ServerAlias packages.mtl
+    RewriteEngine On
+    RewriteCond expr "! %{REQUEST_URI} =~ m#^/nexus/#"
+    RewriteRule "^/(.*)" "/nexus/$1" [R=308]
+    <Location "/nexus/">
+        ProxyPass http://localhost:8081/nexus/ nocanon
+        ProxyPassReverse http://localhost:8081/nexus/
+    </Location>
+</VirtualHost>
+
+# Necessary for http://packages.nmn/ to proxy to nexus.
+<VirtualHost *:80>
+    ProxyPreserveHost On
+    ProxyRequests Off
+    AllowEncodedSlashes NoDecode
+    ProxyTimeout 300
+    ServerName packages.nmn
+    ServerAlias packages.nmn
+    RewriteEngine On
+    RewriteCond expr "! %{REQUEST_URI} =~ m#^/nexus/#"
+    RewriteRule "^/(.*)$" "/nexus/$1" [R=308]
+    <Location "/nexus/">
+        ProxyPass http://localhost:8081/nexus/ nocanon
+        ProxyPassReverse http://localhost:8081/nexus/
+    </Location>
 </VirtualHost>

--- a/scripts/nexus/setup-nexus.sh
+++ b/scripts/nexus/setup-nexus.sh
@@ -32,7 +32,7 @@ DEFAULT_NEXUS_URL='http://packages'
 # Default Nexus registry - this is where csm docker images will be pushed to
 # this does not have http or https purposefully. This is used with skopeo-sync function
 DEFAULT_NEXUS_REGISTRY="registry:5000"
-
+DEFAULT_NEXUS_REGISTRY_PORT="${DEFAULT_NEXUS_REGISTRY#*:}"
 # Defaults defined by Sonatype:
 # https://help.sonatype.com/iqserver/managing/user-management#:~:text=Enter%20the%20current%20password%20(%22admin123,then%20confirm%20the%20new%20password.
 DEFAULT_NEXUS_USERNAME='admin'
@@ -143,6 +143,9 @@ fi
 if [ -z "${NEXUS_REGISTRY:-}" ]; then
     echo >&2 'Missing NEXUS_REGISTRY, presuming default: DEFAULT_NEXUS_REGISTRY'
     NEXUS_REGISTRY="$DEFAULT_NEXUS_REGISTRY"
+    NEXUS_REGISTRY_PORT="$DEFAULT_NEXUS_REGISTRY_PORT"
+else
+    NEXUS_REGISTRY_PORT="${NEXUS_REGISTRY##:*}"
 fi
 
 function nexus-reset() {
@@ -484,7 +487,7 @@ nexus-create-repo-docker() {
   "docker": {
     "v1Enabled": false,
     "forceBasicAuth": false,
-    "httpPort": 5000,
+    "httpPort": "$NEXUS_REGISTRY_PORT",
     "httpsPort": null
   },
   "component": {

--- a/scripts/nexus/setup-nexus.sh
+++ b/scripts/nexus/setup-nexus.sh
@@ -409,6 +409,7 @@ function nexus-delete-repo() {
 }
 
 function nexus-create-repo() {
+    local error=0
     local exists
     local method
     local repo_name="${1:-}"

--- a/scripts/nexus/setup-nexus.sh
+++ b/scripts/nexus/setup-nexus.sh
@@ -461,7 +461,7 @@ nexus-create-repo-docker() {
     fi
 
     if [ "$method" = PUT ]; then
-        uri="$uri/$repo_name"
+        uri="${uri}${repo_name}"
     fi
 
     if ! curl \
@@ -516,7 +516,7 @@ nexus-create-repo-raw() {
     fi
 
     if [ "$method" = PUT ]; then
-        uri="$uri/$repo_name"
+        uri="${uri}${repo_name}"
     fi
 
     if ! curl \
@@ -566,7 +566,7 @@ nexus-create-repo-yum() {
     fi
 
     if [ "$method" = PUT ]; then
-        uri="$uri/$repo_name"
+        uri="${uri}${repo_name}"
     fi
 
     if ! curl \


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: CASMINST-6766
- Relates to: fa3a066046a48896e02017ab57350989f0621ae5

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->
This resolves extraneous errors observed during the updating of the Docker registry on the PIT.

During a fresh install, `setup-nexus.sh` is invoked in order to create/update repositories in Nexus before uploading tarball assets to them. CASMINST-6766 observed an error during the update of the Docker registry, this error is non-fatal, but does cause alarm. The result is the registry's meta fails to update, despite Docker images uploading successfully.

The failure was isolated to be due to a misconfiguration of the Apache2 proxy for nexus, in which some requests fail to route properly.

For example, the failing request in `setup-nexus.sh` was relying on the proxy, in the snippet below we see `http://packages/service` as the base URL
```text
Updating existing repo 'registry' ... + method=PUT
+ nexus-create-repo-docker registry PUT
+ local error=0
+ local repo_name=registry
+ local method=PUT
+ local uri=service/rest/v1/repositories/docker/hosted/
+ '[' -z registry ']'
+ '[' PUT = PUT ']'
+ uri=service/rest/v1/repositories/docker/hosted//registry
+ curl -f -L -u admin:admin123 http://packages/service/rest/v1/repositories/docker/hosted//registry --header 'Content-Type: application/json' --request PUT --data-binary @-
curl: (22) The requested URL returned error: 404
+ error=1
+ '[' 1 -ne 0 ']'
+ echo 'Errors found.'
Errors found.
```

The Nexus log shows a different URL, one that has the `/nexus` sub-path.
```text
 Could not find resource for full path: http://packages/nexus/service/rest/v1/repositories/docker/hosted//registry
```

This PR also addresses some minor, cosmetic issues:
- Removal of the double `//`
- Fix non-numerical return codes from `nexus-create-repo`
- Removal of the Docker registry port hardcode

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [x] I have included documentation in my PR (or it is not required)
- [ ] I have tested this by building an image using this branch HEAD, or this is does not pertain to the node-images pipeline.
- [x] I tested this on internal system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
- [ ] I tested this on a vshasta system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
