### PR TITLE
MTL-2350 New Marvell/QLogic driver

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -28,6 +28,7 @@ kernel:
     standard:
       - libiscsi
       - rpcrdma
+      - qedr
     kdump:
       - mlx5_core
       - mlx5_ib

--- a/scripts/repos/suse.template.repos
+++ b/scripts/repos/suse.template.repos
@@ -93,3 +93,6 @@ https://${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}@artifactory.algol60.net/artifac
 
 # SUSE PTF.1214754 kernel/bonding
 https://${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}@artifactory.algol60.net/artifactory/suse-external/PTF.1214754/${releasever_major}-SP${releasever_minor}/${basearch}?auth=basic                                           SUSE-PTF.1214754                                        -g -p 89
+
+# SUSE PTF.1215587 network recovery kernel panic
+https://${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}@artifactory.algol60.net/artifactory/suse-external/PTF.1215587/${releasever_major}-SP${releasever_minor}/${basearch}?auth=basic                                           SUSE-PTF.1215587                                        -g -p 89

--- a/vars/packages/suse.x86_64.yml
+++ b/vars/packages/suse.x86_64.yml
@@ -41,7 +41,7 @@ packages_x86_64:
   # rationale: Necessary for Mellanox device tools.
   - kernel-mft-mlnx-kmp-default=4.24.0_k5.14.21_150500.55.28-1.sles15sp5
   # rationale: Necessary for advanced QLogic support (CASMTRIAGE-5033)
-  - qlgc-fastlinq-kmp-default=8.72.4.1_k5.14.21_150500.53-8.sles15sp5
+  - qlgc-fastlinq-kmp-default=8.74.1.0_k5.14.21_150500.53-1.sles15sp5
   # rationale: Necessary for collecting hardware information.
   - lshw=B.02.19.2+git.20230320-150200.3.15.4
   # rationale: Necessary for inspecting, configuring, and upgrading Mellanox devices.


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: MTL-2350

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->
Includes a new Marvell/QLogic driver that addresses failed NIC recovery, the new driver allows a NIC to resume normal operations following a firmware stall.

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I have tested this by building an image using this branch HEAD, or this is does not pertain to the node-images pipeline.
- [ ] I tested this on internal system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
- [ ] I tested this on a vshasta system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
