### PR TITLE
MTL-2350 Ensure `qedr` is blacklisted everywhere

### DIFF
--- a/roles/node_images/tasks/main.yml
+++ b/roles/node_images/tasks/main.yml
@@ -32,6 +32,12 @@
     state: present
   loop: "{{ kernel.blacklists.standard }}"
 
+- name: Blacklist kernel modules from dracut
+  ansible.builtin.template:
+    mode: '0644'
+    src: dracut.conf.d/01-blacklist.conf.j2
+    dest: /etc/dracut.conf.d/01-blacklist.conf
+
 - name: Blacklist kernel modules for kdump
   ansible.builtin.lineinfile:
     backrefs: true

--- a/roles/node_images/templates/dracut.conf.d/01-blacklist.conf.j2
+++ b/roles/node_images/templates/dracut.conf.d/01-blacklist.conf.j2
@@ -1,0 +1,24 @@
+#
+# MIT License
+#
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+omit_drivers+=" {{ kernel.blacklists.standard | join(' ') }} " # Needs to start and end with a space to mitigate warnings.

--- a/roles/node_images_metal/files/dracut.conf.d/00-metal.conf
+++ b/roles/node_images_metal/files/dracut.conf.d/00-metal.conf
@@ -27,7 +27,7 @@ force_drivers+=" nvme raid1 " # Needs to start and end with a space to mitigate 
 
 # These are not found and not necessary, omit them to change their "not found" errors into messages for intentionally omitted.
 omit_dracutmodules+=" btrfs cifs dmraid dmsquash-live-ntfs fcoe fcoe-uefi iscsi modsign multipath nbd nfs ntfs-3g " # Needs to start and end with a space to mitigate warnings.
-omit_drivers+=" ecb hmac md5 qedr " # Needs to start and end with a space to mitigate warnings.
+omit_drivers+=" ecb hmac md5 " # Needs to start and end with a space to mitigate warnings.
 
 # kdump.service will automatically use "--compress=xz -0 --check=crc32", but our normal builds should use xz to match.
 compress="xz"

--- a/roles/node_images_metal/files/dracut.conf.d/00-metal.conf
+++ b/roles/node_images_metal/files/dracut.conf.d/00-metal.conf
@@ -27,7 +27,7 @@ force_drivers+=" nvme raid1 " # Needs to start and end with a space to mitigate 
 
 # These are not found and not necessary, omit them to change their "not found" errors into messages for intentionally omitted.
 omit_dracutmodules+=" btrfs cifs dmraid dmsquash-live-ntfs fcoe fcoe-uefi iscsi modsign multipath nbd nfs ntfs-3g " # Needs to start and end with a space to mitigate warnings.
-omit_drivers+=" ecb hmac md5 " # Needs to start and end with a space to mitigate warnings.
+omit_drivers+=" ecb hmac md5 qedr " # Needs to start and end with a space to mitigate warnings.
 
 # kdump.service will automatically use "--compress=xz -0 --check=crc32", but our normal builds should use xz to match.
 compress="xz"


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: MTL-2350
- Relates to: #611 #612 

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->
PRs #611 and #612 blacklisted `qedr`, but it did not blacklist it from the initrd. This PR ensures that `qedr` is always omitted.

Additionally, this ensures that the other modules we want to blacklist aren't included in the initrd. Making our overall blacklisting _cleaner_, matching our hack for (1.2 or 1.3?) where we omitted modules on the NCN's cmdline.

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I have tested this by building an image using this branch HEAD, or this is does not pertain to the node-images pipeline.
- [ ] I tested this on internal system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
- [ ] I tested this on a vshasta system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
