### PR TITLE
MTL-2368 Fix conditional text for vshastav2

### DIFF
--- a/roles/node_images_pre_install_toolkit/files/apache2/nexus.conf
+++ b/roles/node_images_pre_install_toolkit/files/apache2/nexus.conf
@@ -1,4 +1,7 @@
 # Necessary for the IP, pit, and pit.nmn to not be proxied.
+<VirtualHost *:80>
+  ServerName pit.nmn
+</VirtualHost>
 
 # Allow access to all nexus sub-paths.
 <LocationMatch "^/nexus/.*">

--- a/roles/node_images_pre_install_toolkit/files/apache2/nexus.conf
+++ b/roles/node_images_pre_install_toolkit/files/apache2/nexus.conf
@@ -18,7 +18,7 @@
     ProxyPreserveHost On
     AllowEncodedSlashes NoDecode
     ProxyRequests Off
-    ServerName fawkes
+    ServerName pit
     RewriteEngine On
 
     # https://help.sonatype.com/repomanager3/planning-your-implementation/run-behind-a-reverse-proxy#RunBehindaReverseProxy-Apachehttpd.1


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: MTL-2368
- Relates to: #604 #605 

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->
The conditional from [`pitnode_bootstrap.sh`](https://github.com/Cray-HPE/livecd-gcp-infrastructure/blob/7668e6814671e5b76218ab3b8c7a840372c91874/scripts/pitnode_bootstrap.sh#L481) for clobbering `nexus.conf` is evaluating to True, and causing a regression of CASMINST-6766.

This PR restores the text that #604 and #605 needlessly removed.

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I have tested this by building an image using this branch HEAD, or this is does not pertain to the node-images pipeline.
- [ ] I tested this on internal system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
- [x] I tested this on a vshasta system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
