### PR TITLE
update Jenkinsfile for fawkes arm package validation

### DIFF
--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -187,6 +187,30 @@ pipeline {
                                 sh "./scripts/update-package-versions.sh -a aarch64 -p group_vars/compute/packages.suse.aarch64.yml --compute --validate --suffix ${env.SUFFIX}"
                             }
                         }
+
+                        stage('Validate fawkes-live packages') {
+                            steps {
+                                sh "./scripts/update-package-versions.sh -a aarch64 -p group_vars/fawkes_live/packages.suse.yml --validate --suffix ${env.SUFFIX}"
+                            }
+                        }
+
+                        stage('Validate hypervisor packages') {
+                            steps {
+                                sh "./scripts/update-package-versions.sh -a aarch64 -p group_vars/hypervisor/packages.suse.yml --validate --suffix ${env.SUFFIX}"
+                            }
+                        }
+
+                        stage('Validate kubernetes-vm packages') {
+                            steps {
+                                sh "./scripts/update-package-versions.sh -a aarch64 -p group_vars/kubernetes_vm/packages.suse.yml --validate --suffix ${env.SUFFIX}"
+                            }
+                        }
+
+                        stage('Validate management-vm packages') {
+                            steps {
+                                sh "./scripts/update-package-versions.sh -a aarch64 -p group_vars/management_vm/packages.suse.yml --validate --suffix ${env.SUFFIX}"
+                            }
+                        }
                     }
                 }
             }


### PR DESCRIPTION
### Summary and Scope

Missed this in https://github.com/Cray-HPE/metal-provision/pull/619
Update Jenkinsfile to validate packages for aarch64 fawkes images.

#### Issue Type

- Bugfix Pull Request

### Prerequisites

- [x] I have included documentation in my PR (or it is not required)
- [x] I have tested this by building an image using this branch HEAD, or this is does not pertain to the node-images pipeline.
- [x] I tested this on internal system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
 