### PR TITLE
MTL-2375

### DIFF
--- a/roles/node_images/defaults/main.yml
+++ b/roles/node_images/defaults/main.yml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -21,25 +21,8 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
----
-# Kernel options to set by default.
 kernel:
   drivers:
-    standard:
-      - qed
-      - qede
-      - qedf
-      - qedi
-  blacklists:
-    standard:
-      - libiscsi
-      - rpcrdma
-      - qedr
-    kdump:
-      - mlx5_core
-      - mlx5_ib
-      - sunrpc
-      - xhci_hcd
-
-# The desired release of kubeadm, kubelet, and kubectl to use.
-kubernetes_release: 1.22.13
+    standard: []
+  blacklist:
+    standard: []

--- a/roles/node_images/tasks/main.yml
+++ b/roles/node_images/tasks/main.yml
@@ -35,8 +35,8 @@
 - name: Blacklist kernel modules from dracut
   ansible.builtin.template:
     mode: '0644'
-    src: dracut.conf.d/01-blacklist.conf.j2
-    dest: /etc/dracut.conf.d/01-blacklist.conf
+    src: dracut.conf.d/99-csm-ansible.conf.j2
+    dest: /etc/dracut.conf.d/99-csm-ansible.conf
 
 - name: Blacklist kernel modules for kdump
   ansible.builtin.lineinfile:

--- a/roles/node_images/templates/dracut.conf.d/99-csm-ansible.conf.j2
+++ b/roles/node_images/templates/dracut.conf.d/99-csm-ansible.conf.j2
@@ -21,4 +21,5 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
+add_drivers+=" {{ kernel.drivers.standard | join(' ') }} " # Needs to start and end with a space to mitigate warnings.
 omit_drivers+=" {{ kernel.blacklists.standard | join(' ') }} " # Needs to start and end with a space to mitigate warnings.

--- a/scripts/packer/cleanup-functions.sh
+++ b/scripts/packer/cleanup-functions.sh
@@ -250,6 +250,13 @@ function fix_livecd_systemd_remount {
     sed -i -E 's:^(LABEL=)\w+(\s+/\s+):\1cow\2:' /etc/fstab
 }
 
+# Deletes fastlinq.conf.
+function remove_fastlinq_conf {
+    if [ -f /etc/dracut.conf.d/fastlinq.conf ]; then
+        rm -vf /etc/dracut.conf.d/fastlinq.conf
+    fi
+}
+
 function create_release_file {
     local name
     local artifact_version


### PR DESCRIPTION
Adds function to remove `fastlinq.conf`, ensuring `qedr` is blacklisted from the initrd.
