### PR TITLE
CASMTRIAGE-6588

### DIFF
--- a/roles/node_images/files/scripts/common/create-ims-initrd.sh
+++ b/roles/node_images/files/scripts/common/create-ims-initrd.sh
@@ -37,8 +37,18 @@ dracut \
 
 echo "Copying vmlinuz and initrd into /squashfs for disk-bootloader setup."
 rm -f /squashfs/*
-cp -pv /boot/vmlinuz-${KVER} /squashfs/${KVER}.kernel
 cp -pv /boot/initrd-${KVER} /squashfs/initrd.img.xz
+
+if [[ -f /boot/vmlinuz-${KVER} ]]; then
+  # x86_64 kernel
+  cp -pv /boot/vmlinuz-${KVER} /squashfs/${KVER}.kernel
+elif [[ -f /boot/vmlinux-${KVER}.gz ]]; then
+    # aarch64 kernel
+  cp -pv /boot/vmlinux-${KVER}.gz /squashfs/${KVER}.kernel
+else
+    echo "ERROR: No kernel found for version ${KVER}."
+    exit 1
+fi
 
 echo "Purging old kdumps initrd; kdump.service will generate a new one on first boot."
 rm -f /boot/initrd-*-kdump


### PR DESCRIPTION
### Summary and Scope

- Fixes: https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-6588
adapted create-ims-initrd.sh to look for aarch64 and x86_64 kernels

#### Issue Type

- Bugfix Pull Request

### Prerequisites

- [x] I have included documentation in my PR (or it is not required)
- [x] I have tested this by building an image using this branch HEAD, or this is does not pertain to the node-images pipeline.
 
### Risks and Mitigations

none known