### PR TITLE
downgrade metal-ipxe

### DIFF
--- a/group_vars/pre_install_toolkit/packages.suse.yml
+++ b/group_vars/pre_install_toolkit/packages.suse.yml
@@ -32,7 +32,7 @@ packages:
   - cray-site-init=1.32.5-1
   - ilorest=4.2.0.0-20
   - metal-basecamp=1.2.7-1
-  - metal-ipxe=2.5.1-1
+  - metal-ipxe=2.4.7-1
   - metal-init=1.4.8-1
   - metal-nexus=1.4.0-3.38.0_1
   - metal-observability=1.0.9-1


### PR DESCRIPTION
### Summary and Scope

- metal-ipxe was accidentally upgraded to a version incompatible with CSM. Downgrading to metal-ipxe=2.4.7-1

#### Issue Type

- Bugfix Pull Request

### Prerequisites

- [x] I have included documentation in my PR (or it is not required)
- [x] I have tested this by building an image using this branch HEAD, or this is does not pertain to the node-images pipeline.