### PR TITLE
CASMCMS-8905: Removed unintended ability to update all BOS v2 session fields

### DIFF
--- a/group_vars/compute/packages.suse.yml
+++ b/group_vars/compute/packages.suse.yml
@@ -29,7 +29,7 @@ packages:
   - csm-auth-utils=1.0.0-1
   - csm-node-heartbeat=2.5-1
   # CMS Team
-  - bos-reporter=2.13.0-1
+  - bos-reporter=2.14.0-1
   - cfs-debugger=1.5.0-1
   - cfs-state-reporter=1.11.0-1
   - cfs-trust=1.6.8-1

--- a/vars/packages/csm.suse.yml
+++ b/vars/packages/csm.suse.yml
@@ -23,7 +23,7 @@
 #
 ---
 packages:
-  - craycli=0.82.11-1
+  - craycli=0.82.12-1
   - csm-auth-utils=1.0.0-1
   - csm-node-heartbeat=2.5-1
   - csm-node-identity=1.0.22-1


### PR DESCRIPTION
metal-provision PR for https://github.com/Cray-HPE/csm/pull/3165