### PR TITLE
CASMTRIAGE-6598++ -- 1.6

### DIFF
--- a/group_vars/compute/services.suse.yml
+++ b/group_vars/compute/services.suse.yml
@@ -32,11 +32,17 @@ services:
   - enabled: true
     name: cmdline-perm.service
     state: stopped
+  - enabled: false
+    name: cray-memory-spread.service
+    state: stopped
   - enabled: true
     name: csm-node-heartbeat.service
     state: stopped
   - enabled: true
     name: csm-node-identity.service
+    state: stopped
+  - enabled: false
+    name: mlx-set-irq-affinity.service
     state: stopped
   - enabled: true
     name: spire-agent.service

--- a/roles/node_images_metal/files/scripts/metal/create-kis-artifacts.sh
+++ b/roles/node_images_metal/files/scripts/metal/create-kis-artifacts.sh
@@ -88,6 +88,11 @@ fi
 if [[ "$1" != "kernel-initrd-only" ]]; then
   echo "Removing character special files from the filesystem"
   find /mnt/squashfs -type c -exec rm -f '{}' \;
+  
+  echo "Temporarily removing UUID mounts from /etc/fstab"
+  cp -pv /mnt/squashfs/etc/fstab /mnt/squashfs/etc/fstab.orig
+  sed -i '/UUID=.*\/boot\/efi.*/d' /mnt/squashfs/etc/fstab
+
   echo "Creating squashfs artifact"
   mksquashfs /mnt/squashfs \
       /squashfs/filesystem.squashfs \
@@ -98,4 +103,7 @@ if [[ "$1" != "kernel-initrd-only" ]]; then
       -no-recovery \
       -processors "$(nproc)" \
       -e /mnt/squashfs/squashfs/filesystem.squashfs
+
+  echo "Restoring mounts in /etc/fstab"
+  mv -v /mnt/squashfs/etc/fstab.orig /mnt/squashfs/etc/fstab
 fi

--- a/roles/node_images_metal/files/scripts/metal/grub.template.cfg
+++ b/roles/node_images_metal/files/scripts/metal/grub.template.cfg
@@ -43,25 +43,25 @@ fi
 menuentry "$name" --class sles --class gnu-linux --class gnu --class os --unrestricted {
     set gfxpayload=keep
     echo Loading kernel...
-    linuxefi $our_root/$BOOT_LOADER_DIR/kernel mediacheck=0 $linux_cmdline $linux_root $linux_overlay
+    linux $our_root/$BOOT_LOADER_DIR/kernel mediacheck=0 $linux_cmdline $linux_root $linux_overlay
     echo Loading initrd...
-    initrdefi $our_root/$BOOT_LOADER_DIR/initrd.img.xz
+    initrd $our_root/$BOOT_LOADER_DIR/initrd.img.xz
 }
 
 menuentry "$name -- Failsafe" --class sles --class gnu-linux --class gnu --class os --unrestricted {
     set gfxpayload=keep
     echo Loading kernel...
-    linuxefi $our_root/$BOOT_LOADER_DIR/kernel mediacheck=0 $linux_cmdline_failsafe $linux_cmdline $linux_root $linux_overlay
+    linux $our_root/$BOOT_LOADER_DIR/kernel mediacheck=0 $linux_cmdline_failsafe $linux_cmdline $linux_root $linux_overlay
     echo Loading initrd...
-    initrdefi $our_root/$BOOT_LOADER_DIR/initrd.img.xz
+    initrd $our_root/$BOOT_LOADER_DIR/initrd.img.xz
 }
 
 menuentry "Mediacheck" --class sles --class gnu-linux --class gnu --class os --unrestricted {
     set gfxpayload=keep
     echo Loading kernel...
-    linuxefi $our_root/$BOOT_LOADER_DIR/kernel mediacheck=1 $linux_cmdline $linux_root $linux_overlay
+    linux $our_root/$BOOT_LOADER_DIR/kernel mediacheck=1 $linux_cmdline $linux_root $linux_overlay
     echo Loading initrd...
-    initrdefi $our_root/$BOOT_LOADER_DIR/loader/initrd.img.xz
+    initrd $our_root/$BOOT_LOADER_DIR/loader/initrd.img.xz
 }
 
 menuentry "Boot from Hard Disk" --class os --unrestricted {

--- a/roles/node_images_ncn_metal/files/scripts/metal/metal-lib.sh
+++ b/roles/node_images_ncn_metal/files/scripts/metal/metal-lib.sh
@@ -123,9 +123,9 @@ menuentry "$name" --class sles --class gnu-linux --class gnu {
     insmod ext2
     insmod xfs
     echo    'Loading kernel ...'
-    linuxefi \$prefix/../$disk_cmdline
+    linux \$prefix/../$disk_cmdline
     echo    'Loading initial ramdisk ...'
-    initrdefi \$prefix/../initrd.img.xz
+    initrd \$prefix/../initrd.img.xz
 }
 EOF
 }


### PR DESCRIPTION
### Summary and Scope

- replace linuxefi with linux in the grub config
- replace initrdefi with initrd in the grub config
- remove UUID mounts from /etc/fstab for kis and iso artifacts
- disable unecessary COS services in the stock sles compute image

#### Issue Type

- Bugfix Pull Request

### Prerequisites

- [x] I have included documentation in my PR (or it is not required)
- [x] I have tested this by building an image using this branch HEAD, or this is does not pertain to the node-images pipeline.
- [x] I tested this on a vshasta system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)