### PR TITLE
remove sma-cli-utils -- 1.6

### DIFF
--- a/group_vars/ncn/packages.suse.yml
+++ b/group_vars/ncn/packages.suse.yml
@@ -81,5 +81,3 @@ packages:
   - cm-cli=1.5.1-1
   # CVT
   - cvt=1.5.17-20240117100852_9f2ef1967676
-  # SMA
-  - sma-cli-utils=1.5.5-1

--- a/scripts/repos/cray.template.repos
+++ b/scripts/repos/cray.template.repos
@@ -17,6 +17,3 @@ https://${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}@artifactory.algol60.net/artifac
 
 #TEMP Slingshot
 https://${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}@artifactory.algol60.net/artifactory/dst-rpm-mirror/slingshot-host-software-rpm-stable-local/release/slingshot-2.1/sle${releasever_major}_sp${releasever_minor}_ncn?auth=basic     slingshot-2.1                                                                              --no-gpgcheck -p 89
-
-# SMA
-https://${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}@artifactory.algol60.net/artifactory/dst-rpm-mirror/sma-rpm-stable-local/release/sma-1.9/noos?auth=basic                                                                           sma-cli-utils-1.5.4                                                                        --no-gpgcheck -p 89


### PR DESCRIPTION
### Summary and Scope

- remove sma-cli-utils

#### Issue Type

### Prerequisites

- [x] I have included documentation in my PR (or it is not required)
- [x] I have tested this by building an image using this branch HEAD, or this is does not pertain to the node-images pipeline.
 
### Risks and Mitigations

None known. sma-cli-utils is now installed via cloud-init.