### PR TITLE
MTL-2282: create /etc/$NAME-release earlier in the build

### DIFF
--- a/scripts/packer/cleanup-functions.sh
+++ b/scripts/packer/cleanup-functions.sh
@@ -250,35 +250,6 @@ function fix_livecd_systemd_remount {
     sed -i -E 's:^(LABEL=)\w+(\s+/\s+):\1cow\2:' /etc/fstab
 }
 
-function create_release_file {
-    local name
-    local artifact_version
-    local epoch
-    local hash
-    local timestamp
-    name="${1:-''}"
-    artifact_version="${2:-''}"
-    if [ -z "${name}" ]; then
-        echo >&2 'Missing name for release file. Aborting!'
-        return 1
-    fi
-    echo "Making /etc/$name-release ... "
-    if [[ -z "$artifact_version" ]] || [[ "$artifact_version" = 'none' ]]; then
-        hash="dev"
-        epoch="$(date -u +%s%N | cut -b1-13)"
-    else
-        hash="$(echo "$artifact_version" | awk -F- '{print $1}')"
-        epoch="$(echo "$artifact_version" | awk -F- '{print $NF}')"
-    fi
-    timestamp="$(date -d "@${epoch:0:-3}" '+%Y-%m-%d_%H:%M:%S')"
-    cat << EOF > "/etc/${name}-release"
-VERSION=$hash-$epoch
-TIMESTAMP=$timestamp
-EOF
-echo 'Done. Preview:'
-cat "/etc/${name}-release"
-}
-
 function lock_kernel {
     echo 'Locking kernel packages to prevent inadvertent updates ...'
     current_kernel="$(awk -F= '/kernel-default/{gsub("\"", "", $0); print $NF}' /tmp/packages.sh)"

--- a/scripts/packer/setup-functions.sh
+++ b/scripts/packer/setup-functions.sh
@@ -37,6 +37,35 @@ else
     echo "Detected OS family: ${OS}"
 fi
 
+function create_release_file {
+    local name
+    local artifact_version
+    local epoch
+    local hash
+    local timestamp
+    name="${1:-''}"
+    artifact_version="${2:-''}"
+    if [ -z "${name}" ]; then
+        echo >&2 'Missing name for release file. Aborting!'
+        return 1
+    fi
+    echo "Making /etc/$name-release ... "
+    if [[ -z "$artifact_version" ]] || [[ "$artifact_version" = 'none' ]]; then
+        hash="dev"
+        epoch="$(date -u +%s%N | cut -b1-13)"
+    else
+        hash="$(echo "$artifact_version" | awk -F- '{print $1}')"
+        epoch="$(echo "$artifact_version" | awk -F- '{print $NF}')"
+    fi
+    timestamp="$(date -d "@${epoch:0:-3}" '+%Y-%m-%d_%H:%M:%S')"
+    cat << EOF > "/etc/${name}-release"
+VERSION=$hash-$epoch
+TIMESTAMP=$timestamp
+EOF
+echo 'Done. Preview:'
+cat "/etc/${name}-release"
+}
+
 # Prevent the package manager from installing documentation.
 function exclude_docs {
     case "${OS}" in


### PR DESCRIPTION
### Summary and Scope

Create the release file early in the build so that 3rd party RPMs can use it to determine node type. The SDU team will be leveraging this.  The bulk of the code change will be in a node-images PR.

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: MTL-2282

#### Issue Type

<!--- Delete un-needed bullets -->

- RFE Pull Request

<!--- words; describe what this change is and what it is for. -->

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I have tested this by building an image using this branch HEAD, or this is does not pertain to the node-images pipeline.
- [ ] I tested this on internal system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
- [ ] I tested this on a vshasta system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
