### PR TITLE
CASM-4349 - add support for IMS remote build nodes.

### DIFF
--- a/vars/packages/csm.suse.yml
+++ b/vars/packages/csm.suse.yml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -23,7 +23,7 @@
 #
 ---
 packages:
-  - craycli=0.82.12-1
+  - craycli=0.82.13-1
   - csm-auth-utils=1.0.0-1
   - csm-node-heartbeat=2.5-1
   - csm-node-identity=1.0.22-1


### PR DESCRIPTION
### Summary and Scope

[CASM-4349](https://jira-pro.its.hpecorp.net:8443/browse/CASM-4349)

#### Issue Type
- RFE Pull Request

This is adding the api calls to the cray cli for IMS to interact with remote build nodes. 

### Prerequisites
- [X] I have included documentation in my PR (or it is not required)
- [X] I have tested this by building an image using this branch HEAD, or this is does not pertain to the node-images pipeline.
- [X] I tested this on internal system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
 
### Idempotency

This has no impact on anything except the new ims api in craycli. If this is installed on an older system without the update IMS api, all old api's still work exactly as they always have. If the new IMS is installed, but the new cray cli isn't everything will work, but the users will not be able to set remote build nodes through the cray cli. 
 
### Risks and Mitigations

This has very little risk - only updating the cray cli version and that is detailed above. 
