### PR TITLE
Revert "temporary repo for k8s packages"

### DIFF
--- a/scripts/repos/google.template.repos
+++ b/scripts/repos/google.template.repos
@@ -1,1 +1,1 @@
-https://${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}@artifactory.algol60.net/artifactory/google-packages-tmp?auth=basic                        google-packages-tmp               --no-gpgcheck -p 99
+https://${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}@artifactory.algol60.net/artifactory/google-packages-mirror/kubernetes-el7-${basearch}?auth=basic                        google-packages-mirror               --no-gpgcheck -p 99


### PR DESCRIPTION
This reverts commit f2bba0df6db14e23b489a752319177fa12cac103.

### Summary and Scope

google-packages-tmp is no longer needed.
https://cray.slack.com/archives/G01AJCLN36W/p1710451528430629?thread_ts=1710449746.271669&cid=G01AJCLN36W
NOTE: google-packages-mirror is no longer a mirror of google's rpm repository, as google stopped providing that repository.
google-packages-mirror is now a local artifactoryrepo containing only the packges we need.

#### Issue Type

- Bugfix Pull Request

### Prerequisites

- [x] I have included documentation in my PR (or it is not required)
- [x] I have tested this by building an image using this branch HEAD, or this is does not pertain to the node-images pipeline.
  
### Risks and Mitigations

none