### PR TITLE
CASMINST-6834 - CSI generates blank CAN dnsmasq configuration if system configured for CHN

### DIFF
--- a/group_vars/pre_install_toolkit/packages.suse.yml
+++ b/group_vars/pre_install_toolkit/packages.suse.yml
@@ -29,7 +29,7 @@ packages:
   - wol=0.7.1-2.5
   # CSM
   - canu=1.8.1-1
-  - cray-site-init=1.32.5-1
+  - cray-site-init=1.32.6-1
   - ilorest=4.2.0.0-20
   - metal-basecamp=1.2.7-1
   - metal-ipxe=2.4.7-1


### PR DESCRIPTION
### Summary and Scope

- Fixes: [CASMINST-6834](https://jira-pro.it.hpe.com:8443/browse/CASMINST-6834)

#### Issue Type

- Bugfix Pull Request

If a system is configured for CHN then the dnsmasq.d/statics.conf file generated by `csi config init` contains CAN entries with a blank IP address.

```
# DHCP Entries for ncn-s001
dhcp-host=id:x3100c0s19b0n0,set:ncn-s001,5c:ed:8c:86:43:36,5c:ed:8c:21:6f:90,10.1.1.4,ncn-s001,20m # MTL
dhcp-host=id:x3100c0s19b0n0,set:ncn-s001,5c:ed:8c:86:43:36,5c:ed:8c:21:6f:90,10.252.1.6,ncn-s001,20m # Bond0 Mac0/Mac1
dhcp-host=id:x3100c0s19b0n0,set:ncn-s001,5c:ed:8c:86:43:36,5c:ed:8c:21:6f:90,10.254.1.8,ncn-s001,20m # HMN
dhcp-host=id:x3100c0s19b0n0,set:ncn-s001,5c:ed:8c:86:43:36,5c:ed:8c:21:6f:90,,ncn-s001,20m # CAN
dhcp-host=5c:ed:8c:3c:b6:76,10.254.1.7,ncn-s001-mgmt,20m #HMN
# Host Record Entries for ncn-s001
host-record=ncn-s001,ncn-s001.can,
host-record=ncn-s001,ncn-s001.hmn,10.254.1.8
host-record=ncn-s001,ncn-s001.nmn,10.252.1.6
host-record=ncn-s001,ncn-s001.mtl,10.1.1.4
host-record=x3100c0s19b0n0,ncn-s001.nmn,10.252.1.6
host-record=ncn-s001-mgmt,ncn-s001-mgmt.hmn,10.254.1.7
# Override root-path with ncn-s001's xname
dhcp-option-force=tag:ncn-s001,17,x3100c0s19b0n0
```
This has the side effect of DHCP handing out IP addresses from the poll rather than the assigned IP address.

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [X] I have included documentation in my PR (or it is not required)
- [X] I tested this on internal system (if yes, please include results or a description of the test)

Tested on surtur and verified generated configuration was as expected.

#### CAN case
```
# DHCP Entries for ncn-w005
dhcp-host=id:x3000c0s31b0n0,set:ncn-w005,bc:97:e1:e2:95:20,bc:97:e1:e2:95:21,10.1.1.12,ncn-w005,20m # MTL
dhcp-host=id:x3000c0s31b0n0,set:ncn-w005,bc:97:e1:e2:95:20,bc:97:e1:e2:95:21,10.252.1.14,ncn-w005,20m # Bond0 Mac0/Mac1
dhcp-host=id:x3000c0s31b0n0,set:ncn-w005,bc:97:e1:e2:95:20,bc:97:e1:e2:95:21,10.254.1.24,ncn-w005,20m # HMN
dhcp-host=id:x3000c0s31b0n0,set:ncn-w005,bc:97:e1:e2:95:20,bc:97:e1:e2:95:21,10.102.193.143,ncn-w005,20m # CAN
dhcp-host=5c:ba:2c:4a:19:76,10.254.1.23,ncn-w005-mgmt,20m #HMN
# Host Record Entries for ncn-w005
host-record=ncn-w005,ncn-w005.can,10.102.193.143
host-record=ncn-w005,ncn-w005.hmn,10.254.1.24
host-record=ncn-w005,ncn-w005.nmn,10.252.1.14
host-record=ncn-w005,ncn-w005.mtl,10.1.1.12
host-record=x3000c0s31b0n0,ncn-w005.nmn,10.252.1.14
host-record=ncn-w005-mgmt,ncn-w005-mgmt.hmn,10.254.1.23
# Override root-path with ncn-w005's xname
dhcp-option-force=tag:ncn-w005,17,x3000c0s31b0n0
```
 
#### CHN case
```
# DHCP Entries for ncn-w005
dhcp-host=id:x3000c0s31b0n0,set:ncn-w005,bc:97:e1:e2:95:20,bc:97:e1:e2:95:21,10.1.1.12,ncn-w005,20m # MTL
dhcp-host=id:x3000c0s31b0n0,set:ncn-w005,bc:97:e1:e2:95:20,bc:97:e1:e2:95:21,10.252.1.14,ncn-w005,20m # Bond0 Mac0/Mac1
dhcp-host=id:x3000c0s31b0n0,set:ncn-w005,bc:97:e1:e2:95:20,bc:97:e1:e2:95:21,10.254.1.24,ncn-w005,20m # HMN
dhcp-host=5c:ba:2c:4a:19:76,10.254.1.23,ncn-w005-mgmt,20m #HMN
# Host Record Entries for ncn-w005
host-record=ncn-w005,ncn-w005.hmn,10.254.1.24
host-record=ncn-w005,ncn-w005.nmn,10.252.1.14
host-record=ncn-w005,ncn-w005.mtl,10.1.1.12
host-record=x3000c0s31b0n0,ncn-w005.nmn,10.252.1.14
host-record=ncn-w005-mgmt,ncn-w005-mgmt.hmn,10.254.1.23
# Override root-path with ncn-w005's xname
dhcp-option-force=tag:ncn-w005,17,x3000c0s31b0n0
```

### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
