### PR TITLE
CASM-4669 Support container image signatures

### DIFF
--- a/group_vars/pre_install_toolkit/packages.suse.yml
+++ b/group_vars/pre_install_toolkit/packages.suse.yml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -34,5 +34,5 @@ packages:
   - metal-basecamp=1.2.7-1
   - metal-ipxe=2.4.8-1
   - metal-init=1.4.8-1
-  - metal-nexus=1.4.0-3.38.0_1
+  - metal-nexus=1.5.0-3.67.1_1
   - metal-observability=1.0.9-1

--- a/scripts/nexus/setup-nexus.sh
+++ b/scripts/nexus/setup-nexus.sh
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -737,30 +737,12 @@ function nexus-upload-docker-images() {
     {
     load-install-deps
     # Upload images
-    skopeo-sync-with-retry "${CSM_PATH}/docker"
+    skopeo-sync "${CSM_PATH}/docker"
     to_return=$?
     clean-install-deps
     } >/var/log/setup-nexus-docker.log 2>&1
     echo 'Done - Logs available at /var/log/setup-nexus-docker.log'
     return $to_return
-}
-
-function skopeo-sync-with-retry() {
-    local src="$1"
-
-    [[ -d "$src" ]] || return 0
-    declare -a podman_run_flags=(--network host)
-    nexus-setdefault-credential
-    # Note: Have to default NEXUS_USERNAME below since
-    # nexus-setdefault-credential returns immediately if NEXUS_PASSWORD is set.
-    # retries 10 times, takes approx. 15 minutes for all retries
-    podman run --rm "${podman_run_flags[@]}" \
-        -v "$(realpath "$src"):/image:ro" \
-        "$SKOPEO_IMAGE" \
-        sync --scoped --retry-times 10 --src dir --dest docker \
-        --dest-creds "${NEXUS_USERNAME:-admin}:${NEXUS_PASSWORD}" \
-        --dest-tls-verify=false \
-        /image "$NEXUS_REGISTRY"
 }
 
 # If no overrides are set, fetch the credentials.


### PR DESCRIPTION
### Summary and Scope

Make 2 changes required to support copying container images together with Sigstore attachments:
- Upgrade metal-nexus to 3.67.1
- Use vendored version of skope-sync function in setup-nexus.sh, which implies --all CLI option requred for signature passing along with images. Vendored version also implies --retry-times, so dedicated function scope-sync-with-retry is not needed anymore.

- Relates to: CASM-4669

#### Issue Type

- RFE Pull Request

### Prerequisites
- [x] I have included documentation in my PR (or it is not required)
- [x] I have tested this by building an image using this branch HEAD, or this is does not pertain to the node-images pipeline.
- [ ] I tested this on internal system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
- [x] I tested this on a vshasta system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
 
### Idempotency
Please refer to testing description for https://github.com/Cray-HPE/metal-nexus/pull/25 
 
### Risks and Mitigations
This introduces some risk since this change also brings in a newer version of Nexus, but otherwise a new functionality required by CSM 1.6 roadmap can not be achieved.
