### PR TITLE
Add `.mtl` overrides for the local hypervisor

### DIFF
--- a/roles/network_manager/defaults/main.yml
+++ b/roles/network_manager/defaults/main.yml
@@ -31,3 +31,8 @@ network_manager_hypervisor_networks:
   interfaces:
     bonds:
     vlans:
+network_manager_local_hypervisor_aliases:
+  - bootserver
+  - fawkes
+  - packages
+  - registry

--- a/roles/network_manager/tasks/main.yml
+++ b/roles/network_manager/tasks/main.yml
@@ -120,3 +120,23 @@
   when: not isolated_network_exists.failed
   notify:
     - 'network_manager : Restart NetworkManager'
+
+- name: Configure DNS overrides on the local hypervisor
+  ansible.builtin.lineinfile:
+    path: /etc/hosts
+    regexp: "^{{ virt_nets.networks.isolated.dhcp_leases | selectattr('iface', 'match', virt_nets.networks.isolated.bridge)\
+            | map(attribute='ipaddr') | list | first }} {{ item }}.mtl {{ item }}"
+    line: "{{ virt_nets.networks.isolated.dhcp_leases | selectattr('iface', 'match', virt_nets.networks.isolated.bridge)\
+          | map(attribute='ipaddr') | list | first }} {{ item }}.mtl {{ item }}"
+  run_once: true
+  when: not isolated_network_exists.failed
+  loop: "{{ network_manager_local_hypervisor_aliases }}"
+
+- name: Remove old DNS overrides on the local hypervisor
+  ansible.builtin.lineinfile:
+    state: absent
+    path: /etc/hosts
+    regexp: "^{{ virt_nets.networks.isolated.dhcp_leases | selectattr('iface', 'match', virt_nets.networks.isolated.bridge)\
+            | map(attribute='ipaddr') | list | first }} {{ item }}.mtl {{ item }}"
+  when: isolated_network_exists.failed
+  loop: "{{ network_manager_local_hypervisor_aliases }}"


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

#### Issue Type

<!--- Delete un-needed bullets -->

- RFE Pull Request

<!--- words; describe what this change is and what it is for. -->
For service endpoints that live in the management VM, we need to ignore the returned IP and force it to resolve over the isolated network.

```bash
TASK [network_manager : Configure DNS on the local hypervisor] *******************************************************************************************************************************************************************
ok: [hypervisor.local]

TASK [network_manager : Configure DNS overrides on the local hypervisor] *********************************************************************************************************************************************************
changed: [hypervisor.local] => (item=bootserver)
changed: [hypervisor.local] => (item=fawkes)
changed: [hypervisor.local] => (item=packages)
changed: [hypervisor.local] => (item=registry)

TASK [network_manager : Remove old DNS overrides on the local hypervisor] ********************************************************************************************************************************************************
skipping: [hypervisor.local] => (item=bootserver)
skipping: [hypervisor.local] => (item=fawkes)
skipping: [ncn-h002] => (item=bootserver)
skipping: [hypervisor.local] => (item=packages)
skipping: [hypervisor.local] => (item=registry)
skipping: [ncn-h002] => (item=fawkes)
skipping: [ncn-h002] => (item=packages)
skipping: [ncn-h002] => (item=registry)
skipping: [ncn-h003] => (item=bootserver)
skipping: [ncn-h003] => (item=fawkes)
skipping: [ncn-h003] => (item=packages)
skipping: [ncn-h003] => (item=registry)
skipping: [hypervisor.local]
skipping: [ncn-h002]
skipping: [ncn-h004] => (item=bootserver)
skipping: [ncn-h003]
skipping: [ncn-h004] => (item=fawkes)
skipping: [ncn-h004] => (item=packages)
skipping: [ncn-h004] => (item=registry)
skipping: [ncn-h005] => (item=bootserver)
skipping: [ncn-h004]
skipping: [ncn-h005] => (item=fawkes)
skipping: [ncn-h005] => (item=packages)
skipping: [ncn-h005] => (item=registry)
skipping: [ncn-h005]
skipping: [ncn-h006] => (item=bootserver)
skipping: [ncn-h006] => (item=fawkes)
skipping: [ncn-h006] => (item=packages)
skipping: [ncn-h006] => (item=registry)
skipping: [ncn-h006]

PLAY RECAP ***********************************************************************************************************************************************************************************************************************
hypervisor.local           : ok=9    changed=1    unreachable=0    failed=0    skipped=2    rescued=0    ignored=0
ncn-h002                   : ok=5    changed=0    unreachable=0    failed=0    skipped=2    rescued=0    ignored=0
ncn-h003                   : ok=5    changed=0    unreachable=0    failed=0    skipped=2    rescued=0    ignored=0
ncn-h004                   : ok=5    changed=0    unreachable=0    failed=0    skipped=2    rescued=0    ignored=0
ncn-h005                   : ok=5    changed=0    unreachable=0    failed=0    skipped=2    rescued=0    ignored=0
ncn-h006                   : ok=5    changed=0    unreachable=0    failed=0    skipped=2    rescued=0    ignored=0

(ansible) redbull-management:~/rusty # ssh hypervisor
Last login: Fri May  3 09:49:23 2024 from 192.168.0.2
 _   ___   _______ ___________  _   _  _____  ___     _    _____
| | | \ \ / / ___ \  __// ___ \| | | ||_   _|/  _\ .-' `-./ ___ \
| |_| |\ V /| |_/ / |__ | |_/ /| | | |  | |  | |_ ||  _  || |_/ /
|  _  | \ / |  __/|  __||    / | | | |  | |  \__ `|| |_| ||    /
| | | | | | | |   | |___| |\ \ \ \/ /  _| |_  __| ||     || |\ \
\_| |/  |/   \|   |____/|_| \_| \__/  |_____|/___/ `-._.-'|_| \_|

CRAY-HPE Hypervisor OS
pihypervisor:~ # ping packages
PING packages.mtl (192.168.0.2) 56(84) bytes of data.
64 bytes from management-vm.local (192.168.0.2): icmp_seq=1 ttl=64 time=0.130 ms
^C
--- packages.mtl ping statistics ---
1 packets transmitted, 1 received, 0% packet loss, time 0ms
rtt min/avg/max/mdev = 0.130/0.130/0.130/0.000 ms
hypervisor:~ # ping bootserver
PING bootserver.mtl (192.168.0.2) 56(84) bytes of data.
64 bytes from management-vm.local (192.168.0.2): icmp_seq=1 ttl=64 time=0.122 ms
^C
--- bootserver.mtl ping statistics ---
1 packets transmitted, 1 received, 0% packet loss, time 0ms
rtt min/avg/max/mdev = 0.122/0.122/0.122/0.000 ms
```

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I have tested this by building an image using this branch HEAD, or this is does not pertain to the node-images pipeline.
- [x] I tested this on internal system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
- [ ] I tested this on a vshasta system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
