### PR TITLE
MTL-2300 New crucible

### DIFF
--- a/group_vars/fawkes_live/packages.suse.yml
+++ b/group_vars/fawkes_live/packages.suse.yml
@@ -24,7 +24,7 @@
 ---
 packages:
   # rationale: Application for facilitating configuring a hypervisor node.
-  - crucible=0.0.18-1
+  - crucible=0.0.19-1
   # rationale: Goss Health Check Endpoint Service
   - goss-servers=1.17.26-1
   # rationale: Used for poking around the system

--- a/group_vars/fawkes_live/services.suse.yml
+++ b/group_vars/fawkes_live/services.suse.yml
@@ -26,3 +26,6 @@ services:
   - enabled: true
     name: NetworkManager.service
     state: started
+  - enabled: false
+    name: crucible-update.service
+    state: stopped

--- a/group_vars/hypervisor/packages.suse.yml
+++ b/group_vars/hypervisor/packages.suse.yml
@@ -26,7 +26,7 @@ packages:
   # rationale: Security.
   - apparmor-profiles=3.0.4-150500.11.9.1
   # rationale: Application for facilitating configuring a hypervisor node.
-  - crucible=0.0.18-1
+  - crucible=0.0.19-1
   # rationale: Free range routing.
   - frr=8.4-150500.4.15.1
   # rationale: Necessary for running goss tests

--- a/group_vars/hypervisor/services.suse.yml
+++ b/group_vars/hypervisor/services.suse.yml
@@ -29,3 +29,6 @@ services:
   - enabled: true
     name: ssh-import-id.service
     state: stopped
+  - enabled: true
+    name: crucible-update.service
+    state: stopped

--- a/group_vars/management_vm/packages.suse.yml
+++ b/group_vars/management_vm/packages.suse.yml
@@ -26,7 +26,7 @@ packages:
   - aardvark-dns=1.10.0-150500.3.3.1
   - apache2=2.4.51-150400.6.14.1
   - apparmor-profiles=3.0.4-150500.11.9.1
-  - crucible=0.0.18-1
+  - crucible=0.0.19-1
   - dnsmasq=2.86-150400.14.3
   - fawkes-httpboot-grub=1.0-1
   - gnu_parallel=20230122-bp155.1.5

--- a/group_vars/management_vm/services.suse.yml
+++ b/group_vars/management_vm/services.suse.yml
@@ -30,6 +30,9 @@ services:
     name: conman.service
     state: stopped
   - enabled: false
+    name: crucible-update.service
+    state: stopped
+  - enabled: false
     name: dnsmasq.service
     state: stopped
   - enabled: true


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: MTL-2300
- Requires: https://github.com/Cray-HPE/crucible/pull/46

#### Issue Type

<!--- Delete un-needed bullets -->

- RFE Pull Request

<!--- words; describe what this change is and what it is for. -->
New crucible package featuring a systemd daemon for auto-updating the crucible RPM from nexus.

Enables the `crucible-update.service` on hypervisor nodes; disabled in fawkes-live and the management-vm.

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I have tested this by building an image using this branch HEAD, or this is does not pertain to the node-images pipeline.
- [x] I tested this on internal system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
- [ ] I tested this on a vshasta system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
