### PR TITLE
CASMTRIAGE-6991 `goss-servers.service` and CASMPET-7058 vShasta DNSMasq Test Fix

### DIFF
--- a/group_vars/fawkes_live/packages.suse.yml
+++ b/group_vars/fawkes_live/packages.suse.yml
@@ -26,6 +26,6 @@ packages:
   # rationale: Application for facilitating configuring a hypervisor node.
   - crucible=0.0.19-1
   # rationale: Goss Health Check Endpoint Service
-  - goss-servers=1.17.26-1
+  - goss-servers=1.17.27-1
   # rationale: Used for poking around the system
   - gru=0.0.5-1

--- a/group_vars/fawkes_live/packages.suse.yml
+++ b/group_vars/fawkes_live/packages.suse.yml
@@ -26,6 +26,6 @@ packages:
   # rationale: Application for facilitating configuring a hypervisor node.
   - crucible=0.0.19-1
   # rationale: Goss Health Check Endpoint Service
-  - goss-servers=1.17.27-1
+  - goss-servers=1.17.28-1
   # rationale: Used for poking around the system
   - gru=0.0.5-1

--- a/group_vars/fawkes_live/services.suse.yml
+++ b/group_vars/fawkes_live/services.suse.yml
@@ -29,3 +29,6 @@ services:
   - enabled: false
     name: crucible-update.service
     state: stopped
+  - enabled: false
+    name: goss-servers.service
+    state: stopped

--- a/group_vars/hypervisor/packages.suse.yml
+++ b/group_vars/hypervisor/packages.suse.yml
@@ -30,7 +30,7 @@ packages:
   # rationale: Free range routing.
   - frr=8.4-150500.4.15.1
   # rationale: Necessary for running goss tests
-  - goss-servers=1.17.26-1
+  - goss-servers=1.17.27-1
   # rationale: Necessary for Mercury software proof-of-concepts.
   - libguestfs0=1.48.6-150500.3.8.1
   # rationale: Necessary for Mercury software proof-of-concepts.

--- a/group_vars/hypervisor/packages.suse.yml
+++ b/group_vars/hypervisor/packages.suse.yml
@@ -30,7 +30,7 @@ packages:
   # rationale: Free range routing.
   - frr=8.4-150500.4.15.1
   # rationale: Necessary for running goss tests
-  - goss-servers=1.17.27-1
+  - goss-servers=1.17.28-1
   # rationale: Necessary for Mercury software proof-of-concepts.
   - libguestfs0=1.48.6-150500.3.8.1
   # rationale: Necessary for Mercury software proof-of-concepts.

--- a/group_vars/hypervisor/services.suse.yml
+++ b/group_vars/hypervisor/services.suse.yml
@@ -32,3 +32,6 @@ services:
   - enabled: true
     name: crucible-update.service
     state: stopped
+  - enabled: false
+    name: goss-servers.service
+    state: stopped

--- a/group_vars/kubernetes_vm/packages.suse.yml
+++ b/group_vars/kubernetes_vm/packages.suse.yml
@@ -24,4 +24,4 @@
 ---
 packages:
   - apparmor-profiles=3.0.4-150500.11.9.1
-  - goss-servers=1.17.26-1
+  - goss-servers=1.17.27-1

--- a/group_vars/kubernetes_vm/packages.suse.yml
+++ b/group_vars/kubernetes_vm/packages.suse.yml
@@ -24,4 +24,4 @@
 ---
 packages:
   - apparmor-profiles=3.0.4-150500.11.9.1
-  - goss-servers=1.17.27-1
+  - goss-servers=1.17.28-1

--- a/group_vars/kubernetes_vm/services.suse.yml
+++ b/group_vars/kubernetes_vm/services.suse.yml
@@ -23,6 +23,9 @@
 #
 ---
 services:
+  - enabled: false
+    name: goss-servers.service
+    state: stopped
   - enabled: true
     name: wicked.service
     state: started

--- a/group_vars/management_vm/packages.suse.yml
+++ b/group_vars/management_vm/packages.suse.yml
@@ -32,7 +32,7 @@ packages:
   - gnu_parallel=20230122-bp155.1.5
   - gnu_parallel-bash-completion=20230122-bp155.1.5
   - gnu_parallel-zsh-completion=20230122-bp155.1.5
-  - goss-servers=1.17.26-1
+  - goss-servers=1.17.27-1
   - gru=0.0.5-1
   - libcontainers-common=20230214-150500.4.6.1
   - metal-init=1.4.8-1

--- a/group_vars/management_vm/packages.suse.yml
+++ b/group_vars/management_vm/packages.suse.yml
@@ -32,7 +32,7 @@ packages:
   - gnu_parallel=20230122-bp155.1.5
   - gnu_parallel-bash-completion=20230122-bp155.1.5
   - gnu_parallel-zsh-completion=20230122-bp155.1.5
-  - goss-servers=1.17.27-1
+  - goss-servers=1.17.28-1
   - gru=0.0.5-1
   - libcontainers-common=20230214-150500.4.6.1
   - metal-init=1.4.8-1

--- a/group_vars/management_vm/services.suse.yml
+++ b/group_vars/management_vm/services.suse.yml
@@ -38,6 +38,9 @@ services:
   - enabled: true
     name: gitea.service
     state: stopped
+  - enabled: false
+    name: goss-servers.service
+    state: stopped
   - enabled: true
     name: nexus.service
     state: stopped

--- a/group_vars/ncn/packages.suse.yml
+++ b/group_vars/ncn/packages.suse.yml
@@ -73,7 +73,7 @@ packages:
   - cloud-init=23.3.3-1
   - cray-kubectl-hns-plugin=1.0.2-1
   - cray-kubectl-kubelogin-plugin=1.25.3-1
-  - goss-servers=1.17.27-1
+  - goss-servers=1.17.28-1
   - hpe-csm-scripts=0.7.0-1
   - hpe-yq=4.33.3-1
   - loftsman=1.2.0-3

--- a/group_vars/ncn/packages.suse.yml
+++ b/group_vars/ncn/packages.suse.yml
@@ -73,7 +73,7 @@ packages:
   - cloud-init=23.3.3-1
   - cray-kubectl-hns-plugin=1.0.2-1
   - cray-kubectl-kubelogin-plugin=1.25.3-1
-  - goss-servers=1.17.26-1
+  - goss-servers=1.17.27-1
   - hpe-csm-scripts=0.7.0-1
   - hpe-yq=4.33.3-1
   - loftsman=1.2.0-3

--- a/vars/packages/csm.suse.yml
+++ b/vars/packages/csm.suse.yml
@@ -27,7 +27,7 @@ packages:
   - csm-auth-utils=1.0.0-1
   - csm-node-heartbeat=2.6-1
   - csm-node-identity=1.0.22-1
-  - goss-servers=1.17.27-1
+  - goss-servers=1.17.28-1
   - python3-Jinja2=2.10.1-3.10.2
   - python3-MarkupSafe=1.0-1.29
   - python3-PyYAML=5.4.1-1.1

--- a/vars/packages/csm.suse.yml
+++ b/vars/packages/csm.suse.yml
@@ -27,6 +27,7 @@ packages:
   - csm-auth-utils=1.0.0-1
   - csm-node-heartbeat=2.6-1
   - csm-node-identity=1.0.22-1
+  - goss-servers=1.17.27-1
   - python3-Jinja2=2.10.1-3.10.2
   - python3-MarkupSafe=1.0-1.29
   - python3-PyYAML=5.4.1-1.1

--- a/vars/packages/suse.aarch64.yml
+++ b/vars/packages/suse.aarch64.yml
@@ -25,7 +25,7 @@
 packages_aarch64:
   # rationale: Required for running goss tests on aarch64
   - goss=0.3.18-bp155.1.10
-  - goss-servers=1.17.26-1
+  - goss-servers=1.17.27-1
   # rationale: A dependency of SLES's GRUB package.
   - grub2-branding-SLE=15-150400.38.3.1
   # rationale: A dependency needed for the x86_64 EFI GRUB boot loader.

--- a/vars/packages/suse.aarch64.yml
+++ b/vars/packages/suse.aarch64.yml
@@ -23,9 +23,6 @@
 #
 ---
 packages_aarch64:
-  # rationale: Required for running goss tests on aarch64
-  - goss=0.3.18-bp155.1.10
-  - goss-servers=1.17.27-1
   # rationale: A dependency of SLES's GRUB package.
   - grub2-branding-SLE=15-150400.38.3.1
   # rationale: A dependency needed for the x86_64 EFI GRUB boot loader.

--- a/vars/services/csm.suse.yml
+++ b/vars/services/csm.suse.yml
@@ -29,6 +29,9 @@ services:
   - enabled: false
     name: csm-node-identity.service
     state: stopped
+  - enabled: true
+    name: goss-servers.service
+    state: stopped
   - enabled: false
     name: spire-agent.service
     state: stopped


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: CASMTRIAGE-6991 CASMPET-7058
Relates to: 
- https://github.com/Cray-HPE/csm-testing/pull/585
- https://github.com/Cray-HPE/csm-testing/pull/588

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I have tested this by building an image using this branch HEAD, or this is does not pertain to the node-images pipeline.
- [ ] I tested this on internal system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
- [ ] I tested this on a vshasta system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
