### PR TITLE
MTL-2393 Fixed `goss-servers` deps

### DIFF
--- a/group_vars/fawkes_live/packages.suse.yml
+++ b/group_vars/fawkes_live/packages.suse.yml
@@ -26,6 +26,6 @@ packages:
   # rationale: Application for facilitating configuring a hypervisor node.
   - crucible=0.0.19-1
   # rationale: Goss Health Check Endpoint Service
-  - goss-servers=1.17.28-1
+  - goss-servers=1.17.29-1
   # rationale: Used for poking around the system
   - gru=0.0.5-1

--- a/group_vars/hypervisor/packages.suse.yml
+++ b/group_vars/hypervisor/packages.suse.yml
@@ -30,7 +30,7 @@ packages:
   # rationale: Free range routing.
   - frr=8.4-150500.4.15.1
   # rationale: Necessary for running goss tests
-  - goss-servers=1.17.28-1
+  - goss-servers=1.17.29-1
   # rationale: Necessary for Mercury software proof-of-concepts.
   - libguestfs0=1.48.6-150500.3.8.1
   # rationale: Necessary for Mercury software proof-of-concepts.

--- a/group_vars/kubernetes_vm/packages.suse.yml
+++ b/group_vars/kubernetes_vm/packages.suse.yml
@@ -24,4 +24,4 @@
 ---
 packages:
   - apparmor-profiles=3.0.4-150500.11.9.1
-  - goss-servers=1.17.28-1
+  - goss-servers=1.17.29-1

--- a/group_vars/management_vm/packages.suse.yml
+++ b/group_vars/management_vm/packages.suse.yml
@@ -32,7 +32,7 @@ packages:
   - gnu_parallel=20230122-bp155.1.5
   - gnu_parallel-bash-completion=20230122-bp155.1.5
   - gnu_parallel-zsh-completion=20230122-bp155.1.5
-  - goss-servers=1.17.28-1
+  - goss-servers=1.17.29-1
   - gru=0.0.5-1
   - libcontainers-common=20230214-150500.4.6.1
   - metal-init=1.4.8-1

--- a/group_vars/ncn/packages.suse.yml
+++ b/group_vars/ncn/packages.suse.yml
@@ -73,7 +73,7 @@ packages:
   - cloud-init=23.3.3-1
   - cray-kubectl-hns-plugin=1.0.2-1
   - cray-kubectl-kubelogin-plugin=1.25.3-1
-  - goss-servers=1.17.28-1
+  - goss-servers=1.17.29-1
   - hpe-csm-scripts=0.7.0-1
   - hpe-yq=4.33.3-1
   - loftsman=1.2.0-3

--- a/vars/packages/csm.suse.yml
+++ b/vars/packages/csm.suse.yml
@@ -27,7 +27,7 @@ packages:
   - csm-auth-utils=1.0.0-1
   - csm-node-heartbeat=2.6-1
   - csm-node-identity=1.0.22-1
-  - goss-servers=1.17.28-1
+  - goss-servers=1.17.29-1
   - python3-Jinja2=2.10.1-3.10.2
   - python3-MarkupSafe=1.0-1.29
   - python3-PyYAML=5.4.1-1.1


### PR DESCRIPTION
Package `goss-servers` now requires `goss`.

This will fix the missing `goss` binary we hit after the removal of the explicit `goss` callout: https://github.com/Cray-HPE/node-images/actions/runs/9195551941/job/25291695566#step:9:12814
