### PR TITLE
MTL-2414 initrd and kdump initrd additions

### DIFF
--- a/roles/node_images_metal/files/dracut.conf.d/00-metal.conf
+++ b/roles/node_images_metal/files/dracut.conf.d/00-metal.conf
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -45,12 +45,13 @@ use_fstab="yes"
 
 # Install useful tools into the initrd for wiping disks and reading files.
 install_items+=" date less lsblk rmdir sgdisk vgremove wipefs " # Needs to start and end with a space to mitigate warnings.
+install_items+=" dmidecode gzip lsof lspci lsscsi md5sum netcat tar vim xz "  # Needs to start and end with a space to mitigate warnings.
 
 # Ensure our mdadm.conf exists in the initrd to prevent hostnamed MDs.
 mdadmconf="yes"
 
 # Generic options that better align to CSM's usage of the initrd.
-filesystems+=" ext4 fat nls_cp437 nls_iso8859_1 vfat xfs " # Needs to start and end with a space to mitigate warnings.
+filesystems+=" ext4 fat nls_cp437 nls_iso8859_1 squashfs vfat xfs " # Needs to start and end with a space to mitigate warnings.
 machine_id="no"
 persistent_policy="by-label"
 ro_mnt="yes"

--- a/roles/node_images_metal/files/scripts/metal/create-kis-artifacts.sh
+++ b/roles/node_images_metal/files/scripts/metal/create-kis-artifacts.sh
@@ -88,7 +88,7 @@ fi
 if [[ "$1" != "kernel-initrd-only" ]]; then
   echo "Removing character special files from the filesystem"
   find /mnt/squashfs -type c -exec rm -f '{}' \;
-  
+
   echo "Temporarily removing UUID mounts from /etc/fstab"
   cp -pv /mnt/squashfs/etc/fstab /mnt/squashfs/etc/fstab.orig
   sed -i '/UUID=.*\/boot\/efi.*/d' /mnt/squashfs/etc/fstab

--- a/vars/packages/suse.yml
+++ b/vars/packages/suse.yml
@@ -120,6 +120,8 @@ packages:
   - iputils=20221126-150500.3.5.3
   # rationale: Desired for viewing and dumping small computer system interface (SCSI) devices.
   - lsscsi=0.28-1.24
+  # rationale: Easier network traffic debugging.
+  - netcat-openbsd=1.203-150400.1.5
   # rationale: Necessary for openscap.
   - openscap-utils=1.3.6-150400.11.3.1
   # rationale: Necessary for running CVE scans.


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: MTL-2414
- Relates to: CAST-27383

#### Issue Type

<!--- Delete un-needed bullets -->

- RFE Pull Request

<!--- words; describe what this change is and what it is for. -->
Customer has requested that both the kdump and normal initrds for NCNs include more debugging binaries as well as the squashFS kernel module.

While the squashfs kernel module was present in our main initrd, it was not present in the kdump initrd.

This change adds the requested items to our dracut configuration, forcing both `dracut` and `mkdumprd` to include them.

New items:
- `squashfs.ko` (kdump initrd)
- `dmidecode`
- `gzip`
- `lsof`
- `lspci`
- `lsscsi`
- `md5sum`
- `netcat`
- `tar`
- `vim`
- `xz`

NOTE: In order to include `netcat`, the `netcat-openbsd` was needed. This package was added to all node-images via `vars/packages/suse.yml`.

Lastly, the customer requested `lib4_decompress.ko` for the sake of it being a dependency to `squashfs.ko`, however I can not add this driver. Both the normal and kdump initrds already contained the `liblz4.so` library:

```bash
hypervisor:~/rusty # lsinitrd /boot/initrd-5.14.21-150500.55.65-default-kdump | grep -P lz4
-rwxr-xr-x   1 root     root       133544 May  7  2022 usr/lib64/liblz4.so.1.9.3
lrwxrwxrwx   1 root     root           15 Jul 11 21:01 usr/lib64/liblz4.so.1 -> liblz4.so.1.9.3
```

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I have tested this by building an image using this branch HEAD, or this is does not pertain to the node-images pipeline.
- [x] I tested this on internal system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
- [ ] I tested this on a vshasta system or this pertains to the node-images pipeline (if yes and not build related, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 Confirmed none of the requested items are in the kdump initrd:


```bash
# binaries
hypervisor:~/rusty # lsinitrd /boot/initrd-5.14.21-150500.55.65-default-kdump | grep -P '(squashfs|lz4_decompress)\.ko(\.zst)?' ; echo $?
1

# kernel modules
hypervisor:~/rusty # lsinitrd /boot/initrd-5.14.21-150500.55.65-default-kdump | grep -P '/(dmidecode|lspci|lsscsi|lsof|vim|gzip|tar|xz|md5sum|netcat)' ; echo $?
1
```

Confirmed that all requested items were in the kdump initrd with the new dracut configuration:

```bash
# binaries
hypervisor:~/rusty # lsinitrd /boot/initrd-5.14.21-150500.55.65-default-kdump | grep -P '/(dmidecode|lspci|lsscsi|lsof|vim|gzip|tar|xz|md5sum|netcat)' ; echo $?
lrwxrwxrwx   1 root     root           15 Jul 11 21:01 bin/gzip -> ../usr/bin/gzip
lrwxrwxrwx   1 root     root           17 Jul 11 21:01 bin/md5sum -> ../usr/bin/md5sum
lrwxrwxrwx   1 root     root           14 Jul 11 21:01 bin/tar -> ../usr/bin/tar
lrwxrwxrwx   1 root     root           18 Jul 11 21:01 etc/alternatives/vim -> ../../usr/bin/gvim
-rwxr-xr-x   1 root     root        86400 Oct 16  2023 sbin/lspci
-rwxr-xr-x   1 root     root        85816 May  5  2022 usr/bin/gzip
-rwxr-xr-x   1 root     root       168408 May 25  2018 usr/bin/lsof
-rwxr-xr-x   1 root     root        64792 May 25  2018 usr/bin/lsscsi
-rwxr-xr-x   1 root     root        43920 May  7 08:43 usr/bin/md5sum
lrwxrwxrwx   1 root     root            2 Jul 11 21:01 usr/bin/netcat -> nc
-rwxr-xr-x   1 root     root       515600 Dec 13  2023 usr/bin/tar
lrwxrwxrwx   1 root     root           26 Jul 11 21:01 usr/bin/vim -> ../../etc/alternatives/vim
-rwxr-xr-x   1 root     root        76184 Apr  8  2022 usr/bin/xz
-rwxr-xr-x   1 root     root       134232 Apr 19  2023 usr/sbin/dmidecode
0

# kernel modules
hypervisor:~/rusty # lsinitrd /boot/initrd-5.14.21-150500.55.65-default-kdump | grep -P '(squashfs|lz4_decompress)\.ko(\.zst)?' ; echo $?
-rw-r--r--   1 root     root        38326 May 23 10:23 lib/modules/5.14.21-150500.55.65-default/kernel/fs/squashfs/squashfs.ko.zst
0
```

```bash
hypervisor:~/rusty # lsinitrd /boot/initrd-5.14.21-150500.55.65-default-kdump | grep -P lz4
-rwxr-xr-x   1 root     root       133544 May  7  2022 usr/lib64/liblz4.so.1.9.3
lrwxrwxrwx   1 root     root           15 Jul 11 21:01 usr/lib64/liblz4.so.1 -> liblz4.so.1.9.3
```

Testing was done on a 6.1.86 image.

### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->

This does increase the size of our initrd and kdump initrds by about 12% and 33% (respectively).

```bash
hypervisor:~/rusty # du -hs initrd-6.1.86.img.xz initrd-6.1.86-MTL-2414.img.xz
100M	initrd-6.1.86.img.xz
112M	initrd-6.1.86-MTL-2414.img.xz
hypervisor:~/rusty # du -hs initrd-6.1.86-kdump.img.xz initrd-6.1.86-kdump-MTL-2414.img.xz
33M	initrd-6.1.86-kdump.img.xz
45M	initrd-6.1.86-kdump-MTL-2414.img.xz
```