### PR TITLE
MTL-2104 CASMCMS-9041

### DIFF
--- a/group_vars/management_vm/packages.suse.yml
+++ b/group_vars/management_vm/packages.suse.yml
@@ -36,7 +36,7 @@ packages:
   - gru=0.0.5-1
   - libcontainers-common=20240206-150500.4.9.2
   - metal-init=1.4.10-1
-  - metal-ipxe=2.5.1-1
+  - metal-ipxe=2.6.0-1
   - netavark=1.10.2-150500.3.3.3
   - podman=4.4.4-150500.1.4
   - podman-cni-config=4.4.4-150500.1.4

--- a/group_vars/pre_install_toolkit/packages.suse.yml
+++ b/group_vars/pre_install_toolkit/packages.suse.yml
@@ -32,7 +32,7 @@ packages:
   - cray-site-init=1.34.1-1
   - ilorest=4.2.0.0-20
   - metal-basecamp=1.2.7-1
-  - metal-ipxe=2.4.8-1
+  - metal-ipxe=2.4.100-1
   - metal-init=1.4.10-1
   - metal-nexus=1.6.0-3.68.1_1
   - metal-observability=1.0.9-1


### PR DESCRIPTION
New metal-ipxe for Fawkes and CSM:
- Fawkes: metal-ipxe-2.6.0
- CSM: metal-ipxe-2.4.100

Includes updated iPXE source: https://github.com/Cray-HPE/ipxe/pull/11
Includes missing Cray HTTPs/EFI+ACPI code: https://github.com/Cray-HPE/ipxe/pull/12
