### PR TITLE
CASMCMS-9052/CASMTRIAGE-7147: Update BOS reporter and Cray CLI

### DIFF
--- a/group_vars/compute/packages.suse.yml
+++ b/group_vars/compute/packages.suse.yml
@@ -29,7 +29,7 @@ packages:
   - csm-auth-utils=1.0.0-1
   - csm-node-heartbeat=2.6-1
   # CMS Team
-  - bos-reporter=2.20.0-1
+  - bos-reporter=2.22.0-1
   - cfs-state-reporter=1.11.0-1
   - cfs-trust=1.7.0-1
   # CDST GUI Packages

--- a/vars/packages/csm.suse.yml
+++ b/vars/packages/csm.suse.yml
@@ -23,7 +23,7 @@
 #
 ---
 packages:
-  - craycli=0.83.3-1
+  - craycli=0.83.5-1
   - csm-auth-utils=1.0.0-1
   - csm-node-heartbeat=2.6-1
   - csm-node-identity=1.0.22-1


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: https://jira-pro.it.hpe.com:8443/browse/CASMCMS-9052
- Fixes: https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-7147

#### Issue Type

<!--- Delete un-needed bullets -->

- RFE Pull Request

<!--- words; describe what this change is and what it is for. -->

CASMCMS-9052: This updates the BOS reporter RPM to a version which has API request timeouts added.
CASMTRIAGE-7147: Updates the Cray CLI to support the new BOS max_component_batch_size option.