### PR TITLE
MTL-2432 Fix OOM issues when running openscap

### DIFF
--- a/roles/node_images/files/scripts/common/openscap.sh
+++ b/roles/node_images/files/scripts/common/openscap.sh
@@ -23,7 +23,7 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 set -euo pipefail
-
+set -x
 if [ "$RUN_OSCAP" != true ]; then
     touch /tmp/oval-results.xml
     touch /tmp/oval-patch-results.xml
@@ -32,7 +32,7 @@ if [ "$RUN_OSCAP" != true ]; then
     exit 0
 fi
 
-OS_VERSION="$(awk -F= '/VERSION_ID/{gsub(/["]/,"");printf("%d", $NF)}' /etc/os-release)"
+OS_VERSION="$(awk -F= '/VERSION_ID=/{gsub(/["-]/, "") ; print tolower($NF)}' /etc/os-release)"
 
 TEMP_DIR="$(mktemp -d)"
 (


### PR DESCRIPTION
The aggregate sles15 openscap files are too large and cause memory OOM issues during builds. Every time we run into an OOM we have to bump Packer's VM memory.

Instead of downloading a 279M and 395M file for openscap, we can download the smaller 4M and 9M files for the service pack.

```
suse.linux.enterprise.server.15-patch.xml          23-Jul-2024 03:33    279M
suse.linux.enterprise.server.15-patch.xml.bz2      23-Jul-2024 03:33     24M
suse.linux.enterprise.server.15-patch.xml.gz       23-Jul-2024 03:33     41M
suse.linux.enterprise.server.15.xml                23-Jul-2024 03:36    395M
suse.linux.enterprise.server.15.xml.bz2            23-Jul-2024 03:36     10M
suse.linux.enterprise.server.15.xml.gz             23-Jul-2024 03:36     20M
```
vs.
```
suse.linux.enterprise.15-sp6-patch.xml             25-Jul-2024 10:16      4M
suse.linux.enterprise.15-sp6-patch.xml.bz2         25-Jul-2024 10:16    407K
suse.linux.enterprise.15-sp6-patch.xml.gz          25-Jul-2024 10:16    646K
suse.linux.enterprise.15-sp6.xml                   25-Jul-2024 10:17      9M
suse.linux.enterprise.15-sp6.xml.bz2               25-Jul-2024 10:17    515K
suse.linux.enterprise.15-sp6.xml.gz                25-Jul-2024 10:17    744K
```
