### PR TITLE
CASMCMS-9067: Update BOS reporter and Cray CLI

### DIFF
--- a/group_vars/compute/packages.suse.yml
+++ b/group_vars/compute/packages.suse.yml
@@ -29,7 +29,7 @@ packages:
   - csm-auth-utils=1.0.0-1
   - csm-node-heartbeat=2.6-1
   # CMS Team
-  - bos-reporter=2.22.0-1
+  - bos-reporter=2.23.0-1
   - cfs-state-reporter=1.11.0-1
   - cfs-trust=1.7.0-1
   # CDST GUI Packages

--- a/vars/packages/csm.suse.yml
+++ b/vars/packages/csm.suse.yml
@@ -23,7 +23,7 @@
 #
 ---
 packages:
-  - craycli=0.83.5-1
+  - craycli=0.83.6-1
   - csm-auth-utils=1.0.0-1
   - csm-node-heartbeat=2.6-1
   - csm-node-identity=1.0.22-1


### PR DESCRIPTION
CASMCMS-9067 adds a new BOS v2 option. It resulted in a new RPM version for BOS reporter and the Cray CLI. This updates those RPMs. Once this merges, I'll make the corresponding `node-images` PR, and then the CSM manifest PRs.

- Relates to: [CASMCMS-9067](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-9067)

#### Issue Type

- RFE Pull Request

