### PR TITLE
Set `error` in `nexus-delete-repo`

### DIFF
--- a/scripts/nexus/setup-nexus.sh
+++ b/scripts/nexus/setup-nexus.sh
@@ -442,7 +442,7 @@ function setup-apache2-https-proxy() {
 
 function nexus-delete-repo() {
   local name="${1:-}"
-  local error
+  local error=0
   echo >&2 "Deleting $name ..."
   if ! curl \
     -f \


### PR DESCRIPTION
If the `curl` call succeeds in `nexus-delete-repo` an error is emitted:

```
...
* Connection #0 to host packages.local left intact
bash: [: : integer expression expected
Done
bash: return: : numeric argument required
```

On success, `error` is empty (not an integer). By default, `error` should be set to `0`.
