### PR TITLE
CASMCMS-9084 `nf_conntrack_helper` deprecated

### DIFF
--- a/roles/node_images_ncn/files/cloud/templates/metal-iptables.conf.tmpl
+++ b/roles/node_images_ncn/files/cloud/templates/metal-iptables.conf.tmpl
@@ -8,4 +8,8 @@
 -A INPUT -d {{ ip_list[0] }} -p tcp -m tcp --dport 22 -j DROP
 {% endif -%}
 {% endfor %}
+
+# nf_conntrack_helper=1 replacement for kernels 6.0.1 and higher:
+-A PREROUTING -p udp -m udp --dport 69 -j CT --helper tftp
+
 COMMIT

--- a/roles/node_images_ncn/files/sysctl.d/99-cray-ncn-network-common.conf
+++ b/roles/node_images_ncn/files/sysctl.d/99-cray-ncn-network-common.conf
@@ -202,4 +202,3 @@ net.ipv4.udp_l3mdev_accept = 0
 net.ipv4.udp_mem = 85692	114258	171384
 net.ipv4.udp_rmem_min = 4096
 net.ipv4.udp_wmem_min = 4096
-net.netfilter.nf_conntrack_helper = 1


### PR DESCRIPTION
After Kernel 6.0.1 `nf_conntrack_helper` was removed.

To replace it, an iptables prerouting rule can be implemented to help TFTP/UDP packets properly return through a NAT.

This allows TFTP to work from Kubernetes in SLES-15-SP6.
